### PR TITLE
Add links to the global footer to match prototype

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -27,12 +27,12 @@
             'href': '/when-you-get-an-alert'
           },
           {
-            'text': 'How local emergency alerts work',
-            'href': '/how-alerts-work'
-          },
-          {
             'text': 'Reasons you might get an alert',
             'href': '/reasons-you-might-get-an-alert'
+          },
+          {
+            'text': 'How local emergency alerts work',
+            'href': '/how-alerts-work'
           },
           {
             'text': 'Opt out of local emergency alerts',


### PR DESCRIPTION
Adds links to the global footer:

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/87140/108844115-93041680-75d3-11eb-9432-23d5784f8138.png">
