### PR TITLE
Rewrite routes to cope with hosting on sub-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ make build
 make run
 ```
 
+Then visit [localhost:8000/alerts](http://localhost:8000/alerts).
+
 ## Running the tests
 
 ```

--- a/build.py
+++ b/build.py
@@ -9,13 +9,14 @@ from jinja2 import (
     PrefixLoader,
 )
 
-root = Path('.')
-src = root / 'src'
-dist = root / 'dist'
-assets = dist / 'assets'
+repo = Path('.')
+src = repo / 'src'
+dist = repo / 'dist'
+root = dist / 'alerts'
+
 
 jinja_loader = ChoiceLoader([
-    FileSystemLoader(str(root)),
+    FileSystemLoader(str(repo)),
     PrefixLoader({
         'govuk_frontend_jinja': PackageLoader('govuk_frontend_jinja')
     })
@@ -31,10 +32,10 @@ env = Environment(loader=jinja_loader, autoescape=True)
 env.filters['file_fingerprint'] = file_fingerprint
 
 if __name__ == '__main__':
+    root.mkdir(exist_ok=True)
+
     for page in src.glob('**/*.html'):
         template = env.get_template(str(page))
-        target = dist / page.relative_to(src)
+        target = root / page.relative_to(src)
         target.parent.mkdir(exist_ok=True)
         target.open('w').write(template.render())
-
-    assets.mkdir(exist_ok=True)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,8 @@ plugins.postcss = require('gulp-postcss');
 
 const paths = {
   src: 'src/assets/',
-  dist: 'dist/assets/',
   node_modules: 'node_modules/',
+  dist: 'dist/alerts/assets/',
   govuk_frontend: 'node_modules/govuk-frontend/'
 };
 

--- a/src/404.html
+++ b/src/404.html
@@ -4,5 +4,5 @@
 
 {% block content %}
   <h1>Content not found</h1>
-  <a href='index.html'>Go back to homepage</a>
+  <a href="/alerts'>Go back to homepage</a>
 {% endblock %}

--- a/src/assets/stylesheets/_govuk_frontend.scss
+++ b/src/assets/stylesheets/_govuk_frontend.scss
@@ -5,7 +5,7 @@
 // All imports come from node_modules/govuk-frontend/govuk
 
 // set asset URL root to match that of application
-$govuk-assets-path: "/assets/";
+$govuk-assets-path: "/alerts/assets/";
 
 @import "govuk/base";
 

--- a/src/index.html
+++ b/src/index.html
@@ -10,16 +10,16 @@
   </h1>
   <ul>
     <li>
-      <a href='/when-you-get-an-alert'>What happens when you get an alert</a>
+      <a href='/alerts/when-you-get-an-alert'>What happens when you get an alert</a>
     </li>
     <li>
-      <a href='/how-alerts-work'>How local emergency alerts work</a>
+      <a href='/alerts/how-alerts-work'>How local emergency alerts work</a>
     </li>
     <li>
-      <a href='/reasons-you-might-get-an-alert'>Reasons you might get an alert</a>
+      <a href='/alerts/reasons-you-might-get-an-alert'>Reasons you might get an alert</a>
     </li>
     <li>
-      <a href='/opt-out'>Opt out of local emergency alerts</a>
+      <a href='/alerts/opt-out'>Opt out of local emergency alerts</a>
     </li>
   </ul>
 {% endblock %}

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -1,23 +1,23 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 
 {% block headIcons %}
-  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ '/assets/images/favicon.ico' | file_fingerprint }}" type="image/x-icon" />
-  <link rel="mask-icon" href="{{ '/assets/images/govuk-mask-icon.svg' | file_fingerprint }}" color="#0b0c0c"> {# Hardcoded value of $govuk-black #}
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/govuk-apple-touch-icon-180x180.png' | file_fingerprint }}">
-  <link rel="apple-touch-icon" sizes="167x167" href="{{ '/assets/images/govuk-apple-touch-icon-167x167.png' | file_fingerprint }}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{{ '/assets/images/govuk-apple-touch-icon-152x152.png' | file_fingerprint }}">
-  <link rel="apple-touch-icon" href="{{ '/assets/images/govuk-apple-touch-icon.png' | file_fingerprint }}">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ '/alerts/assets/images/favicon.ico' | file_fingerprint }}" type="image/x-icon" />
+  <link rel="mask-icon" href="{{ '/alerts/assets/images/govuk-mask-icon.svg' | file_fingerprint }}" color="#0b0c0c"> {# Hardcoded value of $govuk-black #}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ '/alerts/assets/images/govuk-apple-touch-icon-180x180.png' | file_fingerprint }}">
+  <link rel="apple-touch-icon" sizes="167x167" href="{{ '/alerts/assets/images/govuk-apple-touch-icon-167x167.png' | file_fingerprint }}">
+  <link rel="apple-touch-icon" sizes="152x152" href="{{ '/alerts/assets/images/govuk-apple-touch-icon-152x152.png' | file_fingerprint }}">
+  <link rel="apple-touch-icon" href="{{ '/alerts/assets/images/govuk-apple-touch-icon.png' | file_fingerprint }}">
 {% endblock %}
 
 {% block head %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <link media="print" href={{ "/assets/stylesheets/main-print.css" | file_fingerprint }} rel="stylesheet">
-  <link media="screen" href={{ "/assets/stylesheets/main.css" | file_fingerprint }} rel="stylesheet">
+  <link media="print" href={{ "/alerts/assets/stylesheets/main-print.css" | file_fingerprint }} rel="stylesheet">
+  <link media="screen" href={{ "/alerts/assets/stylesheets/main.css" | file_fingerprint }} rel="stylesheet">
 
   {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
   <!--[if lt IE 9]>
-    <script src="/assets/javascripts/vendor/html5shiv/html5shiv.min.js"></script>
+    <script src="/alerts/assets/javascripts/vendor/html5shiv/html5shiv.min.js"></script>
   <![endif]-->
 {% endblock %}
 
@@ -30,19 +30,19 @@
         'items': [
           {
             'text': 'What to do when you get an alert',
-            'href': '/when-you-get-an-alert'
+            'href': '/alerts/when-you-get-an-alert'
           },
           {
             'text': 'Reasons you might get an alert',
-            'href': '/reasons-you-might-get-an-alert'
+            'href': '/alerts/reasons-you-might-get-an-alert'
           },
           {
             'text': 'How local emergency alerts work',
-            'href': '/how-alerts-work'
+            'href': '/alerts/how-alerts-work'
           },
           {
             'text': 'Opt out of local emergency alerts',
-            'href': '/opt-out'
+            'href': '/alerts/opt-out'
           }
         ]
       }


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1443052

This reflects the fact that the site is hosted on a '/alerts' path,
so the files we distribute and the links between them need to match
that. While we could use a Jinja filter to abstract some of this, I
think it's simpler to just move everything under '/alerts/'.