### PR TITLE
Add links to meta section in the footer

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -51,7 +51,19 @@
       'items': [
         {
           'text': 'GOV.UK home page',
-          'href': 'https://www.gov.uk'
+          'href': '/'
+        },
+        {
+          'text': 'Privacy',
+          'href': '/help/privacy-notice'
+        },
+        {
+          'text': 'Accessibility statement',
+          'href': '/help/accessibility-statement'
+        },
+        {
+          'text': 'Terms and conditions',
+          'href': '/help/terms-conditions'
         }
       ]
     }


### PR DESCRIPTION
I *think* should link to the privacy and accessibility statements and the terms and conditions because they all cover the content in our pages.

This adds them to the footer.

## Now

<img width="989" alt="footer_meta_links" src="https://user-images.githubusercontent.com/87140/109324818-18dec680-784d-11eb-9fdf-2800de50d280.png">

## With these changes

<img width="988" alt="new_footer_meta_links" src="https://user-images.githubusercontent.com/87140/109324841-2005d480-784d-11eb-8672-45605dd27e18.png">
