### PR TITLE
Tell browsers to preload fonts

### DIFF
--- a/build.py
+++ b/build.py
@@ -30,6 +30,12 @@ def file_fingerprint(path):
 
 env = Environment(loader=jinja_loader, autoescape=True)
 env.filters['file_fingerprint'] = file_fingerprint
+env.globals = {
+    'font_paths': [
+        item.relative_to(dist)
+        for item in root.glob('assets/fonts/*.woff2')
+    ],
+}
 
 if __name__ == '__main__':
     root.mkdir(exist_ok=True)

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -12,6 +12,9 @@
 {% block head %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
+  {%- for font in font_paths %}
+  <link rel="preload" href="/{{ font }}" as="font" type="font/woff2" crossorigin>
+  {%- endfor %}
   <link media="print" href={{ "/alerts/assets/stylesheets/main-print.css" | file_fingerprint }} rel="stylesheet">
   <link media="screen" href={{ "/alerts/assets/stylesheets/main.css" | file_fingerprint }} rel="stylesheet">
 


### PR DESCRIPTION
This copies the work done in https://github.com/alphagov/notifications-admin/pull/3754

***

Our font files are referenced from our CSS. This means that the browser has to download and parse the CSS before it knows where to find the font files. This means the requests happen in sequence.

We can make the requests happen in parallel by using a `<link>` tag with `rel=preload`. This tells the browser to start downloading the fonts before it’s even started downloading the CSS (the CSS will be the next thing to start downloading, since it’s the next `<link>` element in the head of the HTML).

Downloading fonts before things like images is important because once the font is downloaded it causes the layout to repaint, and shift everything around. So the page doesn’t feel stable until after the fonts have loaded.

Google call this [cumulative layout shift](https://web.dev/cls/) which is a score for how much the page moves around. A lower score means a better experience (and, less importantly for us, means the page might rank higher in search results)

We’re only preloading the WOFF2 fonts because only modern browsers support preload, and these browsers also all support WOFF2.

We set an empty `crossorigin` attribute (which means anonymous-mode) because the preload request needs to match the origin’s CORS mode. See https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content#CORS-enabled_fetches
for more details.

We set `as=font` because this helps the browser use the correct content security policy, and prioritise which requests to make first.

We don’t need to fingerprint the font files because they come with their own hash in the filename already.

# Before 

![image](https://user-images.githubusercontent.com/355079/110914537-690a5e00-830e-11eb-812a-74c778808646.png)

# After

![image](https://user-images.githubusercontent.com/355079/110914428-45471800-830e-11eb-915e-9eabdfa4083a.png)
