### PR TITLE
Fix simple issues from accessibility audit

### DIFF
--- a/src/alert.html
+++ b/src/alert.html
@@ -48,7 +48,7 @@
     <p class="govuk-body">
       Sent to England, Northern Ireland, Scotland and Wales.
     </p>
-    <img src={{ "/alerts/assets/images/map-of-uk-static.png" | file_fingerprint }} height="275" width="590" alt="map showing the area the alert was sent to"/>
+    <img src={{ "/alerts/assets/images/map-of-uk-static.png" | file_fingerprint }} height="275" width="590" alt="map showing the area the alert was sent to: England, Northern Ireland, Scotland and Wales"/>
     <p class="govuk-body">
       Surrounding areas might also have received the alert.
     </p>

--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -52,6 +52,9 @@
       <p class="govuk-body">
         You can also find them on your phone or tablet.
       </p>
+      {% set androidButton %}
+        <span class="govuk-visually-hidden">Find alerts on </span>Android devices
+      {% endset %}
       {% set androidAdvice %}
         <p class="govuk-body">
             Search your settings for ‘emergency alerts’ and select <b class="govuk-!-font-weight-bold">Emergency alert history</b>.
@@ -61,16 +64,19 @@
         </p>
       {% endset %}
       {{ govukDetails({
-        "summaryText": "Android devices",
+        "summaryHtml": androidButton,
         "html": androidAdvice
       }) }}
+      {% set iosButton %}
+        <span class="govuk-visually-hidden">Find alerts on </span>iPhone and iPad
+      {% endset %}
       {% set iosAdvice %}
         <p class="govuk-body">
             Swipe down on the home screen to view your notifications. If you clear your notifications you’ll delete the alert.
         </p>
       {% endset %}
       {{ govukDetails({
-        "summaryText": "iPhone and iPad",
+        "summaryHtml": iosButton,
         "html": iosAdvice
       }) }}
       <h2 class="govuk-heading-m">

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -13,7 +13,7 @@
         </p>
         <a href="/alerts/alert" class="govuk-link govuk-body">
           More information about this alert 
-          <span class="govuk-visually-hidden">to {{ areas }}</span>
+          <span class="govuk-visually-hidden"> to {{ areas }}</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Fixes for the simplest issues that came out of our accessibility audit, all of which effected users of screen readers. Based on pairing with @karlchillmaid.

See this google sheet for details of the issues: https://docs.google.com/spreadsheets/d/1lLWHKTC5P0eL2oVxD25quuA4YThmj7yRKX5L4EivyQs/edit?usp=sharing

The issues tackled in this pull request are:
1. the alt text of the map doesn't contain enough
   information (issue 2)
2. the buttons for the `<details>` sections on
   /alerts/when-you-get-an-alert don't make sense
   out of context (issue 3)
3. the 'More information about this alert' link
   doesn't make sense out of context (issue 4)

This fixes those issues by:
1. making the map alt text include the areas the
   alert was sent to
2. giving the `<details>` buttons hidden prefixes to
   explain what you're looking for on each
   type of device
3. this link had hidden text giving it context
   already but it didn't have a space separating it
   from the rest. This has been added

## Notes for reviewers

If you feel confident with a screen reader, you could check these changes yourself. If not, you can look at the content screen readers will announce using either the [Firefox accessibility inspector](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector#features_of_the_accessibility_panel) or [Chrome's accessibility pane](https://developer.chrome.com/docs/devtools/accessibility/reference/#computed).