### PR TITLE
Give current alert heading a hidden suffix

### DIFF
--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -6,7 +6,7 @@
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48) }}
         <h2 class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-1">
-          {{ areas }}
+          <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ areas }}
         </h2>
         <p class="alerts-alert__message govuk-body-l govuk-!-margin-bottom-4">
           {{ message }}


### PR DESCRIPTION
The accessibility audit raised an issue with the
headings for each alert listed on the
/alerts/current-alerts page, saying it was
confusing for screen reader users when viewed out
of context.

Currently:

'England, Northern Ireland, Scotland, and Wales'

Proposed version:

'Emergency alert sent to England, Northern
 Ireland, Scotland, and Wales'

Our version just explains what it is, something
you get from its context in the page visually.

## Notes for reviewers

If you feel confident with a screen reader, you could check these changes yourself. If not, you can look at the content screen readers will announce using either the [Firefox accessibility inspector](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector#features_of_the_accessibility_panel) or [Chrome's accessibility pane](https://developer.chrome.com/docs/devtools/accessibility/reference/#computed).