### PR TITLE
Reference IE8 stylesheet in the layout

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -21,7 +21,12 @@
   {# prefetch block for any files needed in future navigations - doesn't block resources for the current page #}
   {% block prefetch %}{% endblock %}
   <link media="print" href={{ "/alerts/assets/stylesheets/main-print.css" | file_fingerprint }} rel="stylesheet">
+  <!--[if !IE 8]><!-->
   <link media="screen" href={{ "/alerts/assets/stylesheets/main.css" | file_fingerprint }} rel="stylesheet">
+  <!--<![endif]-->
+  <!--[if IE 8]>
+  <link media="screen" href={{ "/alerts/assets/stylesheets/main-ie8.css" | file_fingerprint }} rel="stylesheet">
+  <![endif]-->
 
   {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
   <!--[if lt IE 9]>


### PR DESCRIPTION
The IE8-specific stylesheet was created but not
referenced in the HTML when the pages were first
built. (In https://github.com/alphagov/notifications-govuk-alerts/pull/8/files.)

This adds the <link> for it to the <head> of the
document using the method suggested by the design
system team:

https://frontend.design-system.service.gov.uk/supporting-ie8/#4-include-the-ie8-stylesheet-in-your-project