### PR TITLE
Tighten conditionals in build script

### DIFF
--- a/build.py
+++ b/build.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     for page in src.glob('*.html'):
         template = env.get_template(str(page))
 
-        if 'alert.html' in str(page):
+        if str(page) == 'src/alert.html':
             for alert in data['alerts']:
                 target = root / alert['identifier']
                 target.open('w').write(template.render({'alert_data': alert}))


### PR DESCRIPTION
This first one was too general, meaning it was catching pages it wasn’t supposed to. For example `when-you-get-an-alert.html` contains `alert.html`. It was then trying to render this page as if it were the template for a current alert and failing.