### PR TITLE
Fix example image text colour to govuk-black

### DIFF
--- a/templates/components/example.html
+++ b/templates/components/example.html
@@ -31,7 +31,7 @@
         {% set top_padding = 14 + 7 %}
         {% set top_position = top_padding + icon_height + 3 %}
         <rect id="phonePopup" fill="#e6ecf3" x="30" y="157" height="{{ top_position + (popup_text|length * line_height) + line_height }}" width="255" rx="6" />
-        <g id="phonePopupText" transform="translate(44,157)" font-family="arial,sans-serif">
+        <g id="phonePopupText" transform="translate(44,157)" font-family="arial,sans-serif" fill="#0b0c0c">
           {{ alerts_icon(height=icon_height, y=font_size) }}
           <text font-size="{{ font_size }}" font-weight="bold" x="40" y="{{ top_padding +  font_size }}">Emergency alert</text>
           {% for line in popup_text %}


### PR DESCRIPTION
We don't currently set a colour for the text in the (SVG) example alert image. This means it inherits the colour from the browser defaults (and so the OS).

If Windows is set to high contrast mode, which sets the text to a light colour (white by default), the text becomes illegible. This sets it to always be the [GOVUK black](https://design-system.service.gov.uk/styles/colour/#colour-palette) so it always maintains the right contrast ratio with the background.

## Before

<img width="956" alt="windows_high_contrast_white_on_black_before" src="https://user-images.githubusercontent.com/87140/116232386-f9cbba80-a751-11eb-93d8-614c48a5af34.png">

## After

<img width="1020" alt="windows_high_contrast_white_on_black_after" src="https://user-images.githubusercontent.com/87140/116232410-ffc19b80-a751-11eb-8fe1-c89be4aed7fd.png">
