### PR TITLE
Make relative-dates.js work with no times

### DIFF
--- a/src/assets/javascripts/relative-dates.js
+++ b/src/assets/javascripts/relative-dates.js
@@ -7,6 +7,8 @@ function relativeDates () {
   var parentNode
   var prefix
 
+  if (nodes.length === 0) return
+
   render(nodes)
 
   for (i = 0; i < nodesLength; i++) {


### PR DESCRIPTION
The home page has 2 states:
1. with no current alerts
2. with some current alerts (shows banner at top)

This means state 1. will have no datetimes in page
for relative-dates.js to operate on. This case was
missed from the pull request that removed alerts
from data.yaml:

https://github.com/alphagov/notifications-govuk-alerts/pull/32