### PR TITLE
Change ‘threats’ to ‘alerts’

### DIFF
--- a/src/opt-out.html
+++ b/src/opt-out.html
@@ -40,7 +40,7 @@
         Android phones and tablets
       </h2>
       <p class="govuk-body">
-        To opt out, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Severe threats</b>.
+        To opt out, search your settings for ‘emergency alerts’ and turn off <b class="govuk-!-font-weight-bold">Severe alerts</b>.
       </p>
       <p class="govuk-body">
         If this does not work, contact your device manufacturer.


### PR DESCRIPTION
Once Android devices have the latest updates they will use the UK term (alerts) not the US/international default (threats).

Screenshot from an up-to-date Pixel phone:

![Screenshot_20210415-175243](https://user-images.githubusercontent.com/355079/117269607-557ffd00-ae50-11eb-9609-062fb1f519bd.png)
