### PR TITLE
Change fallback method for SVG images

### DIFF
--- a/templates/components/alerts_icon.html
+++ b/templates/components/alerts_icon.html
@@ -8,7 +8,7 @@
   {% if degrade %}
     <!--<![endif]-->
     <!--[if IE 8]>
-      <img src="/alerts/assets/images/alert.png" height="{{ height }}" width="{{ width }}", alt="{{ alt }}" class="example alerts-image__image--centred alerts-icon__fallback" />
+      <img src="/alerts/assets/images/alert.png" height="{{ height }}" width="{{ width }}", alt="{{ alt }}" class="example alerts-image__image--centred" />
     <![endif]-->
   {% endif %}
 {% endmacro %}

--- a/templates/components/example.html
+++ b/templates/components/example.html
@@ -41,6 +41,6 @@
       </g>
     </svg>
     <!--<![endif]-->
-    <!--[if IE 8]><img src="/alerts/assets/images/example.png" height="436" width="306", alt="{{ alt }}" class="example alerts-image__image--centred alerts-icon__fallback" /><![endif]-->
+    <!--[if IE 8]><img src="/alerts/assets/images/example.png" height="436" width="306", alt="{{ alt }}" class="example alerts-image__image--centred" /><![endif]-->
   </div>
 {% endmacro %}


### PR DESCRIPTION
Since adding a Content Security Policy, we're getting violation errors due to the use of data URIs in our page. This is because of the fallback method we use for our SVG images.

<img width="731" alt="Content Security Policy: The page's settings blocked the loading of a resource at data:, ('default-src')." src="https://user-images.githubusercontent.com/87140/117284424-b44c7300-ae5e-11eb-9341-ccc4ef9289cd.png">

The current fallback method works like this:
- we put a `<image>` tag in the SVG that uses an empty data URI for the image data and the SVG attribute of `display="none"` so it doesn't show up in browsers that support SVG
- the `<image>` tag includes a `src` attribute, pointing to a fallback image

Because browsers interpret `<image>` as `<img>`, those that don't support SVG:
- ignore all the SVG tags
- interpret `<image>` as an `<img>` tag and display the image its `src` points to

The problem with this is that using data URIs violates our Content Security Policy.

The new fallback method is to just wrap SVGs in [conditional comments](https://css-tricks.com/how-to-create-an-ie-only-stylesheet/) that ensure it is only delivered to Internet Explorer (IE) 8 and above, as well as all other browsers. This does mean that any browsers that don't support SVG but aren't IE will no
longer get the fallback but this seems limited to quite old versions of Android's native browser:

https://caniuse.com/svg

The latest one of these was released in 2010 so I think this risk is reasonable.

These changes extend the interface of the alerts_icon component to allow the conditional comments to be optional. This is because we nest it in the example component, which is wrapped in conditional comments itself so any child SVGs it
includes don't need them.

Note: The very latest GOVUK Frontend also contains this issue but it has been raised with the team and is scheduled to be worked on soon:

https://github.com/alphagov/govuk-frontend/issues/2203

We don't use this version yet so can hold off until they roll out a solution (which we may yet copy).