### PR TITLE
Tighten spacing between the details element

### DIFF
--- a/src/when-you-get-an-alert.html
+++ b/src/when-you-get-an-alert.html
@@ -66,7 +66,8 @@
       {% endset %}
       {{ govukDetails({
         "summaryHtml": androidButton,
-        "html": androidAdvice
+        "html": androidAdvice,
+        "classes": "govuk-!-margin-bottom-3"
       }) }}
       {% set iosButton %}
         <span class="govuk-visually-hidden">Find alerts on </span>iPhone and iPad


### PR DESCRIPTION
By default the details element has a full 30px space. They work better here with something closer to inter-paragraph spacing.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/118098131-705fed80-b3cb-11eb-9b83-f7eb70c2fcb3.png) | ![image](https://user-images.githubusercontent.com/355079/118098096-63db9500-b3cb-11eb-9404-df5b817ce707.png)
