### PR TITLE
Add a bit of spacing above the images on mobile

### DIFF
--- a/src/assets/stylesheets/components/image.scss
+++ b/src/assets/stylesheets/components/image.scss
@@ -1,6 +1,12 @@
+@import "govuk/settings/all";
+@import "govuk/helpers/all";
+
 .alerts-image {
   &__container--centred {
     text-align: center;
+    @include govuk-media-query($until: tablet) {
+      margin-top: govuk-spacing(5);
+    }
   }
 
   &__image--centred {


### PR DESCRIPTION
When they are not side-by-side with the text they need a bit more space to breathe.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/118279889-8a7cf700-b4c3-11eb-84a0-4c4ca1715cf3.png) | ![image](https://user-images.githubusercontent.com/355079/118279808-75a06380-b4c3-11eb-8e47-7e3fbac60205.png)
