### PR TITLE
Merge integration of EAS-503 and EAS-504

### DIFF
--- a/app/templates/views/how-alerts-work.html
+++ b/app/templates/views/how-alerts-work.html
@@ -70,7 +70,7 @@
           not compatible
         </li>
       </ul>
-      <h2 id="syntax-2" class="scroll-mt-20 govuk-heading-l">
+      <h2 id="compatible-devices" class="scroll-mt-20 govuk-heading-l">
         Compatible mobile phones and other devices
       </h2>
       <p class="govuk-body">
@@ -88,7 +88,7 @@
         </li>
       </ul>
       <p class="govuk-body">
-        If you have an earlier version of Android, you may still be able to receive alerts. To check, search your device settings for ’emergency alerts’.
+        If you have an earlier version of Android, you may still be able to receive alerts. To check, search your device settings for ‘emergency alerts’.
       </p>
       <h2 class="govuk-heading-l">
         If you want to see an alert again
@@ -104,7 +104,7 @@
         If you get reminders about an alert
       </h2>
       <p class="govuk-body">
-        Android phones and tablets may get more than one reminder about the same emergency alert. You can turn these reminders off through the ’emergency alerts’ settings on your phone.
+        Android phones and tablets may get more than one reminder about the same emergency alert. You can turn these reminders off through the ‘emergency alerts’ settings on your phone.
       </p>
       <h2 class="govuk-heading-l">
         Opting out of emergency alerts

--- a/app/templates/views/how-alerts-work.html
+++ b/app/templates/views/how-alerts-work.html
@@ -70,7 +70,7 @@
           not compatible
         </li>
       </ul>
-      <h2 class="govuk-heading-l">
+      <h2 id="syntax-2" class="scroll-mt-20 govuk-heading-l">
         Compatible mobile phones and other devices
       </h2>
       <p class="govuk-body">

--- a/app/templates/views/how-alerts-work.html
+++ b/app/templates/views/how-alerts-work.html
@@ -39,34 +39,39 @@
         How emergency alerts work
       </h1>
       <p class="govuk-body">
-        Emergency alerts work like a radio broadcast.
-      </p>
-      <p class="govuk-body">
         In an emergency, mobile phone masts in the surrounding area will broadcast an alert. Every compatible mobile phone or tablet in range of a mast will receive the alert.
       </p>
-      <h2 class="govuk-heading-l">
-        What you need to know
-      </h2>
+      <div class="govuk-inset-text">
+        Emergency alerts work on all 4G and 5G phone networks in the UK.
+      </div>
       <p class="govuk-body">
-        The emergency services and the UK government do not need your phone number to send you an alert.
-      </p>
-      <p class="govuk-body">
-        You will get alerts based on your current location – not where you live or work.
-      </p>
-      <p class="govuk-body">
-        No one will collect or share data about you, your device or your location when you receive an alert.
-      </p>
-      <p class="govuk-body">
-        You will not get alerts if your device is turned off or in aeroplane mode.
+        Your mobile phone or tablet does not have to be connected to mobile data or wifi to get alerts.
       </p>
       <p class="govuk-body">
         Emergency alerts are free. You do not need to sign up for them or download an app.
       </p>
+      <h2 class="govuk-heading-l">
+        Reasons you will not get an alert
+      </h2>
       <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/opt-out">opt out of some emergency alerts</a>, but you should keep them switched on for your own safety.
+        You will not receive alerts if your device is:
       </p>
-      <h2 class="govuk-heading-m" id="phone-handsets-and-devices">
-        Phone handsets and devices
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          turned off or in airplane mode
+        </li>
+        <li>
+          connected to a 2G or 3G network
+        </li>
+        <li>
+          wifi only
+        </li>
+        <li>
+          not compatible
+        </li>
+      </ul>
+      <h2 class="govuk-heading-l">
+        Compatible mobile phones and other devices
       </h2>
       <p class="govuk-body">
         Make sure your device has all the latest software updates.
@@ -75,33 +80,59 @@
         Emergency alerts work on:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>iPhones running iOS 14.5 or later</li>
-        <li>Android phones and tablets running Android 11 or later</li>
+        <li>
+          iPhones running iOS 14.5 or later
+        </li>
+        <li>
+          Android phones and tablets running Android 11 or later
+        </li>
       </ul>
       <p class="govuk-body">
-        If you have an earlier version of Android, you may still be able to receive alerts. To check, search your settings for ‘emergency alerts’.
+        If you have an earlier version of Android, you may still be able to receive alerts. To check, search your device settings for ’emergency alerts’.
       </p>
-      <h2 class="govuk-heading-m" id="mobile-phone-networks">
-        Mobile phone networks
+      <h2 class="govuk-heading-l">
+        If you want to see an alert again
       </h2>
       <p class="govuk-body">
-        Emergency alerts work on all 4G and 5G phone networks in the UK.
+        To see an alert again, go to <a class="govuk-link" href="/alerts/current-alerts">current emergency alerts</a> or
+        <a class="govuk-link" href="/alerts/past-alerts">past emergency alerts</a>.
       </p>
       <p class="govuk-body">
-        Phones and tablets connected to a 2G or 3G network will not receive emergency alerts.
+        You can also search for emergency alerts on your mobile phone or tablet.
       </p>
-      <p class="govuk-body">
-        Emergency alerts do not cause, and are not affected by, busy phone networks.
-      </p>
-      <h2 class="govuk-heading-m" id="cannot-get-alerts">
-        If you cannot receive emergency alerts
+      <h2 class="govuk-heading-l">
+        If you get reminders about an alert
       </h2>
       <p class="govuk-body">
-        The emergency services have other ways to warn you when lives are in danger.
+        Android phones and tablets may get more than one reminder about the same emergency alert. You can turn these reminders off through the ’emergency alerts’ settings on your phone.
+      </p>
+      <h2 class="govuk-heading-l">
+        Opting out of emergency alerts
+      </h2>
+      <p class="govuk-body">
+        You can opt out of emergency alerts, but you should keep them switched on for your own safety.
       </p>
       <p class="govuk-body">
-        Emergency alerts will not replace local news, radio, television or social media.
+        To opt out:
       </p>
+      <ul class="govuk-list">
+        <ol type="1">
+          <li>Search your settings for ‘emergency alerts’.</li>
+          <li>Turn off ‘severe alerts’ and ‘extreme alerts’.</li>
+        </ol>
+      </ul>
+      <p class="govuk-body">
+        If you still get alerts, contact your device manufacturer for help.
+      </p>
+      <h2 class="govuk-heading-l">
+        Your personal data
+      </h2>
+      <p class="govuk-body">
+        The emergency services and the UK government do not need your phone number to send you an alert.
+      </p>
+      <div class="govuk-inset-text">
+        Data about you, your device or location will not be collected or shared.
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -132,7 +132,7 @@
       </div>
       <h2 class="govuk-heading-l">If you cannot receive emergency alerts</h2>
       <p class="govuk-body">
-        If you do not have a compatible device, you’ll still be informed about an emergency. The emergency services have other ways to warn you when there is a threat to life.
+        If you do not have a <a class="govuk-link" href="/alerts/how-alerts-work#compatible-devices">compatible device</a>, you’ll still be informed about an emergency. The emergency services have other ways to warn you when there is a threat to life.
       </p>
       <div class="govuk-inset-text">
         Emergency alerts will not replace local news, radio, television or social media.


### PR DESCRIPTION
Merging the integration of content changes to the root page (EAS-503) with the content changes to the "how-alerts-work" page (EAS-504) - primarily, the "compatible devices" link to the "how-alerts-work" compatible-devices section of the page.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
