### PR TITLE
Layout header modifications to fit new content designs

### DIFF
--- a/app/assets/stylesheets/_govuk_frontend.scss
+++ b/app/assets/stylesheets/_govuk_frontend.scss
@@ -21,6 +21,7 @@ $govuk-new-link-styles: true;
 @import "govuk/components/details/index";
 @import "govuk/components/button/index";
 @import "govuk/components/inset-text/index";
+@import "govuk/components/phase-banner/index";
 
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";

--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -38,14 +38,15 @@
 {% block header %}
   <script async type="text/javascript" src="{{ '/alerts/assets/javascripts/govuk-frontend-skip-link.js' | file_fingerprint }}"></script>
   {{ govukHeader({
-    'assetsPath': '/alerts/assets/images'
+    'assetsPath': '/alerts/assets/images',
+    "serviceName": "Emergency Alerts"
   }) }}
   <div class="govuk-width-container">
     {{ govukPhaseBanner({
       'tag': {
         'text': "beta"
       },
-      'text': 'Service currently in trial tbc'
+      'text': 'This is a new service that is being trialled.'
     }) }}
   </div>
 {% endblock %}

--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -1,5 +1,7 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 
+{%- from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner -%}
+
 {% block pageTitle %}{% block pageTitleCurrent %}{% endblock %} - GOV.UK{% endblock %}
 
 {% block headIcons %}
@@ -38,6 +40,14 @@
   {{ govukHeader({
     'assetsPath': '/alerts/assets/images'
   }) }}
+  <div class="govuk-width-container">
+    {{ govukPhaseBanner({
+      'tag': {
+        'text': "beta"
+      },
+      'text': 'Service currently in trial tbc'
+    }) }}
+  </div>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Changes to the header in the layout used across all pages of the application, to:

- Service Name - "Emergency Alerts" added to the centre of the GOVUK Header
- Beta Banner - "This is a new service that is being trialled.", added with the tag "BETA" to pages, using the GOVUK phase banner component.

These are in line with new content requirements, stipulated as part of the new content design wireframes/prototypes.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
