### PR TITLE
Jan 30 2023 Deployment - No alerts status box, BETA banner

### DIFF
--- a/app/assets/stylesheets/_govuk_frontend.scss
+++ b/app/assets/stylesheets/_govuk_frontend.scss
@@ -21,6 +21,7 @@ $govuk-new-link-styles: true;
 @import "govuk/components/details/index";
 @import "govuk/components/button/index";
 @import "govuk/components/inset-text/index";
+@import "govuk/components/phase-banner/index";
 
 @import "govuk/utilities/all";
 @import "govuk/overrides/all";

--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -1,5 +1,7 @@
 {% extends "govuk_frontend_jinja/template.html" %}
 
+{%- from "govuk_frontend_jinja/components/phase-banner/macro.html" import govukPhaseBanner -%}
+
 {% block pageTitle %}{% block pageTitleCurrent %}{% endblock %} - GOV.UK{% endblock %}
 
 {% block headIcons %}
@@ -38,6 +40,14 @@
   {{ govukHeader({
     'assetsPath': '/alerts/assets/images'
   }) }}
+  <div class="govuk-width-container">
+    {{ govukPhaseBanner({
+      'tag': {
+        'text': "beta"
+      },
+      'text': 'Service currently in trial tbc'
+    }) }}
+  </div>
 {% endblock %}
 
 {% block content %}

--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -45,7 +45,7 @@
       'tag': {
         'text': "beta"
       },
-      'text': 'Service currently in trial tbc'
+      'text': 'This is a new service that is being trialled.'
     }) }}
   </div>
 {% endblock %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -45,6 +45,11 @@
   {% elif alerts.dates_of_current_and_planned_test_alerts %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     {{ planned_tests_banner(alerts.current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts) }}
+  {% else %}
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <h2 class="govuk-heading-m" id="subsection-title">
+      There are no current alerts
+    </h2>
   {% endif %}
 
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-bottom-8">

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -11,7 +11,7 @@ from tests.conftest import create_planned_test_dict
 def test_index_page(client_get):
     html = client_get("alerts")
     assert html.select_one('h1').text.strip() == "Emergency Alerts"
-    assert 'current alert' not in html.text
+    assert 'There are no current alerts' in html.text
 
 
 @pytest.mark.parametrize('planned_tests', (


### PR DESCRIPTION
Changes to be deployed on Jan 30, 2023:
----

1. Status box on index page that shows "There are no current alerts" if there are no alerts.
2. Phase banner shows BETA and trialling text.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
