### PR TITLE
Update Welsh index page to /alerts/about.cy

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -106,7 +106,7 @@ def get_rendered_pages(alerts):
             continue
 
         if target == 'index.cy':
-            rendered['alerts.cy'] = template.render()
+            rendered['alerts/about.cy'] = template.render()
             continue
 
         rendered["alerts/" + target] = template.render()

--- a/app/templates/views/alert.cy.html
+++ b/app/templates/views/alert.cy.html
@@ -38,7 +38,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       },
       parentBreadcrumb,
     ]

--- a/app/templates/views/current-alerts.cy.html
+++ b/app/templates/views/current-alerts.cy.html
@@ -33,7 +33,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       }
     ]
   }) }}
@@ -74,7 +74,7 @@
         "items": [
           {
             "text": "Am Rybuddion Argyfwng",
-            "href": "/alerts.cy"
+            "href": "/alerts/about.cy"
           },
           {
             "text": "Sut mae'r rhybuddion argyfwng yn gweithio",

--- a/app/templates/views/how-alerts-work.cy.html
+++ b/app/templates/views/how-alerts-work.cy.html
@@ -28,7 +28,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       }
     ]
   }) }}
@@ -153,7 +153,7 @@
         "items": [
           {
             "text": "Am Rybuddion Argyfwng",
-            "href": "/alerts.cy"
+            "href": "/alerts/about.cy"
           },
           {
             "text": "Profion ar y gweill",

--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -15,7 +15,7 @@
   {{ metaTags(
     description="Your mobile phone or tablet may get an emergency alert if there’s a danger to life nearby. Alerts tell you what to do to stay safe.",
     title=pageTitle,
-    url="https://www.gov.uk/alerts.cy"
+    url="https://www.gov.uk/alerts/about.cy"
   ) }}
 {% endblock %}
 

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -48,7 +48,7 @@
       {{ hmrcLanguageSelect({
         'language': 'en',
         'cy': {
-          'href': '/alerts.cy'
+          'href': '/alerts/about.cy'
         }
       }) }}
     </div>

--- a/app/templates/views/past-alerts.cy.html
+++ b/app/templates/views/past-alerts.cy.html
@@ -33,7 +33,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       }
     ]
   }) }}
@@ -80,7 +80,7 @@
         "items": [
           {
             "text": "Am Rybuddion Argyfwng",
-            "href": "/alerts.cy"
+            "href": "/alerts/about.cy"
           },
           {
             "text": "Sut mae'r rhybuddion argyfwng yn gweithio",

--- a/app/templates/views/planned-tests.cy.html
+++ b/app/templates/views/planned-tests.cy.html
@@ -28,7 +28,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       }
     ]
   }) }}
@@ -73,7 +73,7 @@
         "items": [
           {
             "text": "Am Rybuddion Argyfwng",
-            "href": "/alerts.cy"
+            "href": "/alerts/about.cy"
           },
           {
             "text": "Sut mae'r rhybuddion argyfwng yn gweithio",

--- a/app/templates/views/system-testing.cy.html
+++ b/app/templates/views/system-testing.cy.html
@@ -33,7 +33,7 @@
       },
       {
         "text": "Am Rybuddion Argyfwng",
-        "href": "/alerts.cy"
+        "href": "/alerts/about.cy"
       }
     ]
   }) }}
@@ -82,7 +82,7 @@
         "items": [
           {
             "text": "Am Rybuddion Argyfwng",
-            "href": "/alerts.cy"
+            "href": "/alerts/about.cy"
           },
           {
             "text": "Sut mae'r rhybuddion argyfwng yn gweithio",

--- a/tests/app/main/test_local_links.py
+++ b/tests/app/main/test_local_links.py
@@ -14,7 +14,7 @@ def get_local_route_from_template_path(template_path):
     if local_route != '/alerts/index' and local_route != '/alerts/index.cy':
         return local_route
     elif local_route == '/alerts/index.cy':  # Welsh index
-        return '/alerts.cy'
+        return '/alerts/about.cy'
     else:  # index page is mapped to root of /alerts directory
         return '/alerts'
 


### PR DESCRIPTION
This PR changes the Welsh index page route to /alerts/about.cy, so that all pages are under the /alerts/ route, which will fix the 404 issue in the staging environment.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
