### PR TITLE
Replace location headings with 'Mobile network operator test'

### DIFF
--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -5,9 +5,15 @@
     <div class="govuk-grid-column-full">
       <div class="alerts-icon__container alerts-icon__container--48">
         {{ alerts_icon(height=48, alert_active=alert.is_current) }}
-        <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{% if alert.display_areas %}{{ alert.display_areas | formatted_list(before_each='', after_each='') }}{% elif not alert.is_public %}Mobile network operator test{% endif %}
-        </h{{ heading_level }}>
+        {% if not alert.is_public %}
+          <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
+              Mobile network operator test
+          </h{{ heading_level }}>
+        {% else %}
+          <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
+          </h{{ heading_level }}>
+        {% endif %}
         {{ alert_body(alert) }}
         {% if alert.is_public %}
           {% if language == 'cy' %}

--- a/app/templates/views/planned-tests.cy.html
+++ b/app/templates/views/planned-tests.cy.html
@@ -102,7 +102,9 @@
       </h2>
     {% endif %}
     <h2 class="govuk-heading-m govuk-!-margin-top-6">
-      {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+      {% if alert_or_planned_test.is_public %}
+        {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+      {% endif %}
     </h2>
     {% if not alert_or_planned_test.is_public %}
       <p class="govuk-body">

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -101,7 +101,9 @@
       </h2>
     {% endif %}
     <h2 class="govuk-heading-m govuk-!-margin-top-6">
-      {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+      {% if alert_or_planned_test.is_public %}
+        {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+      {% endif %}
     </h2>
     {% if not alert_or_planned_test.is_public %}
       <p class="govuk-body">

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -15,7 +15,7 @@ def test_past_alerts_page(client_get):
 @pytest.mark.parametrize('is_public,expected_title,expected_link_text', [
     [
         False,
-        'Emergency alert sent to foo',
+        'Mobile network operator test',
         '',
     ],
     [

--- a/tests/app/main/views/test_planned_tests.py
+++ b/tests/app/main/views/test_planned_tests.py
@@ -33,7 +33,7 @@ def test_planned_tests_page(mocker, client_get):
                        'search for gov.uk/alerts',
             'areas': {'names': ['Ibiza']}
         })],
-        ['Wednesday 3 February 2021', 'Ibiza'],
+        ['Wednesday 3 February 2021', ''],
         [],
         [
             'There will be a mobile phone network test of the UK Emergency Alerts service today.',
@@ -58,7 +58,7 @@ def test_planned_tests_page(mocker, client_get):
             'content': 'Paragraph 1\n\nParagraph 2',
             'areas': {'names': ['Ibiza', 'The Norfolk Broads']}
         })],
-        ['Wednesday 3 February 2021', 'Ibiza and The Norfolk Broads'],
+        ['Wednesday 3 February 2021', ''],
         [],
         [
             'There will be a mobile phone network test of the UK Emergency Alerts service today.',
@@ -93,7 +93,7 @@ def test_planned_tests_page(mocker, client_get):
             }),
         ],
         [
-            'Wednesday 3 February 2021', 'Ibiza', 'The Norfolk Broads'
+            'Wednesday 3 February 2021', '', ''
         ],
         [],
         [
@@ -163,7 +163,7 @@ def test_planned_tests_page_with_current_operator_test(
     assert [
         normalize_spaces(h2.text) for h2 in html.select('.govuk-grid-column-two-thirds h2')
     ] == [
-        'Wednesday 21 April 2021', "None"
+        'Wednesday 21 April 2021', ''
     ]
     assert not html.select('main h3')
     assert [

--- a/tests/app/models/test_alerts.py
+++ b/tests/app/models/test_alerts.py
@@ -77,6 +77,8 @@ def test_planned_alerts(alert_dict, planned_test_dict, mocker):
     assert len(Alerts([alert_dict] + [planned_test_dict]).planned) == 0
 
     mocker.patch(__name__ + '.PlannedTest.is_planned', True)
+    mocker.patch(__name__ + '.Alert.is_planned', True)
+    mocker.patch(__name__ + '.Alert.is_public', False)
     assert len(Alerts([alert_dict] + [planned_test_dict]).planned) == 2
 
 

--- a/tests/app/models/test_alerts.py
+++ b/tests/app/models/test_alerts.py
@@ -77,8 +77,6 @@ def test_planned_alerts(alert_dict, planned_test_dict, mocker):
     assert len(Alerts([alert_dict] + [planned_test_dict]).planned) == 0
 
     mocker.patch(__name__ + '.PlannedTest.is_planned', True)
-    mocker.patch(__name__ + '.Alert.is_planned', True)
-    mocker.patch(__name__ + '.Alert.is_public', False)
     assert len(Alerts([alert_dict] + [planned_test_dict]).planned) == 2
 
 


### PR DESCRIPTION
Replace location headings with 'Mobile network operator test' for all appearances of an MNO test, including in planned tests and when displayed in past alerts. This does not interfere with actual alerts (or public tests), where the actual alert location will be displayed when planned, when current, and when in past alerts.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
