### PR TITLE
Fix planned test status box out of sync with planned tests page

### DIFF
--- a/app/models/alerts.py
+++ b/app/models/alerts.py
@@ -90,16 +90,12 @@ class Alerts(SerialisedModelCollection):
         }
 
     @property
-    def planned_non_public_tests(self):
-        return [
-            planned_test for planned_test
-            in self.planned_tests
-            if planned_test.is_planned and not planned_test.is_public
-        ]
-
-    @property
     def current_and_planned_test_alerts(self):
-        return self.test_alerts_today + self.planned_non_public_tests
+        return [
+            planned for planned
+            in self.planned
+            if not planned.is_public
+        ]
 
     @property
     def all_current_and_planned_test_alerts(self):

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -113,7 +113,7 @@
         Most mobile phones and tablets will not get a test alert.
       </p>
       <p class="govuk-body">
-        Find out more about <a href="/alerts/system-testing.cy" class="govuk-link">testing the Emergency Alerts service</a>.
+        Find out more about <a href="/alerts/system-testing" class="govuk-link">testing the Emergency Alerts service</a>.
       </p>
     {% endif %}
     <p class="govuk-body">


### PR DESCRIPTION
The following fixes the issue where a planned test will be shown in the status box, but not reflected on the planned tests page when clicked through to it. This is due to the status box checking only for a match in the date (thereby allowing the planned test to display all day), while the planned tests page checks the time for expiry. The status box now uses the planned function to verify whether the test alert has expired.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
