### PR TITLE
Display multiple status box permutations when applicable

### DIFF
--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -54,15 +54,19 @@
       }) }}
     </div>
   </div>
-  {% if alerts.current_and_public %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ banner(alerts.current_and_public | length, alerts.last_updated_date, lang='cy') }}
-  {% elif alerts.dates_of_current_and_planned_test_alerts %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ service_tests_banner(alerts.current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts, lang='cy') }}
-  {% elif alerts.dates_of_planned_test_alerts %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ national_test_banner(alerts.dates_of_planned_test_alerts, lang='cy') }}
+  {% if alerts.current_and_public or alerts.dates_of_current_and_planned_test_alerts or alerts.dates_of_planned_test_alerts %}
+    {% if alerts.current_and_public %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ banner(alerts.current_and_public | length, alerts.last_updated_date, lang='cy') }}
+    {% endif %}
+    {% if alerts.dates_of_planned_test_alerts %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ national_test_banner(alerts.dates_of_planned_test_alerts, lang='cy') }}
+    {% endif %}
+    {% if alerts.dates_of_current_and_planned_test_alerts %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ service_tests_banner(alerts.dates_of_current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts, lang='cy') }}
+    {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-m" id="subsection-title">

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -53,15 +53,19 @@
       }) }}
     </div>
   </div>
-  {% if alerts.current_and_public %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
-  {% elif alerts.dates_of_current_and_planned_test_alerts %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ service_tests_banner(alerts.dates_of_current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts) }}
-  {% elif alerts.dates_of_planned_test_alerts %}
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    {{ national_test_banner(alerts.dates_of_planned_test_alerts) }}
+  {% if alerts.current_and_public or alerts.dates_of_current_and_planned_test_alerts or alerts.dates_of_planned_test_alerts %}
+    {% if alerts.current_and_public %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
+    {% endif %}
+    {% if alerts.dates_of_planned_test_alerts %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ national_test_banner(alerts.dates_of_planned_test_alerts) }}
+    {% endif %}
+    {% if alerts.dates_of_current_and_planned_test_alerts %}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {{ service_tests_banner(alerts.dates_of_current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts) }}
+    {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-m" id="subsection-title">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from dateutil.parser import parse as dt_parse
 
 from app import create_app
 from app.models.alerts import Alerts
+from app.models.planned_tests import PlannedTests
 
 
 def create_alert_dict(
@@ -78,6 +79,7 @@ def govuk_alerts():
 @pytest.fixture()
 def client_get(govuk_alerts, mocker):
     mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([]))
+    mocker.patch('app.models.planned_tests.PlannedTests.from_yaml', return_value=PlannedTests([]))
     mocker.patch('app.render.file_fingerprint', return_value='1234')
 
     def _do_get(path):


### PR DESCRIPTION
Display multiple status box permutations when applicable, as opposed to overriding by precedence, in order to ensure that the announcement status box is still displayed, even if there is also a current alert and/or a service test (i.e., status boxes stacked atop one another in order of precedence).


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
