### PR TITLE
EAS-862 Add National Test time to banner and announcement

### DIFF
--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -69,11 +69,6 @@ class AlertDate(object):
         return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y} at {dt:%-I%p}'
 
     @property
-    def as_alert_date_lang(self, lang='en-GB'):
-        dt = self._local_datetime
-        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y}'
-
-    @property
     def as_iso8601(self):
         return self._local_datetime.isoformat()
 

--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -42,6 +42,12 @@ class AlertDate(object):
         return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y}'
 
     @property
+    def datetime_as_lang(self):
+        dt = self._local_datetime
+        meridiem = f'{dt:%p}'.lower()
+        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y} at {dt:%-I}{meridiem}'
+
+    @property
     def as_url(self):
         """
         * non-zero padded day
@@ -60,7 +66,7 @@ class AlertDate(object):
     @property
     def as_alert_lang(self, lang='en-GB'):
         dt = self._local_datetime
-        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y}, at {dt:%-I%p}'
+        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y} at {dt:%-I%p}'
 
     @property
     def as_alert_date_lang(self, lang='en-GB'):

--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -64,11 +64,6 @@ class AlertDate(object):
         return f'at {self.time_as_lang} on {self.date_as_lang}'
 
     @property
-    def as_alert_lang(self, lang='en-GB'):
-        dt = self._local_datetime
-        return f'{dt:%A} {dt.day} {dt:%B} {dt:%Y} at {dt:%-I%p}'
-
-    @property
     def as_iso8601(self):
         return self._local_datetime.isoformat()
 

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -18,7 +18,7 @@
   {% set title %}
     {% for alert_date in dates_of_test_alerts|sort %}
       {% if loop.index == 1 %}
-        On {{ alert_date.as_alert_date_lang }}, there will be a national test of the UK Emergency Alerts service.
+        On {{ alert_date.datetime_as_lang }}, there will be a national test of the UK Emergency Alerts service.
       {% endif %}
     {% endfor %}
   {% endset %}

--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -100,7 +100,7 @@
     {% endif %}
     {% if loop.first %}
       <h2 class="govuk-heading-m {% if not date_loop.first %}govuk-!-margin-top-9{% endif %}">
-        {{ alert_or_planned_test.starts_at_date.date_as_lang }}
+        {{ alert_or_planned_test.starts_at_date.datetime_as_lang }}
       </h2>
     {% endif %}
     <h2 class="govuk-heading-m govuk-!-margin-top-6">

--- a/app/templates/views/announcements.html
+++ b/app/templates/views/announcements.html
@@ -99,7 +99,7 @@
     {% endif %}
     {% if loop.first %}
       <h2 class="govuk-heading-m {% if not date_loop.first %}govuk-!-margin-top-9{% endif %}">
-        {{ alert_or_planned_test.starts_at_date.date_as_lang }}
+        {{ alert_or_planned_test.starts_at_date.datetime_as_lang }}
       </h2>
     {% endif %}
     <h2 class="govuk-heading-m govuk-!-margin-top-6">

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -2,9 +2,9 @@ planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-24T19:00:00Z
+    finishes_at: 2023-04-24T15:00:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In an actual emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -20,9 +20,9 @@ planned_tests:
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-24T19:00:00Z
+    finishes_at: 2023-04-24T15:00:00Z
     content: |
       Prawf ar Rybuddion Argyfwng yw hwn, sef gwasanaeth newydd gan lywodraeth y DU a fydd yn eich rhybuddio pan fydd argyfwng sy'n berygl i fywyd gerllaw.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -1,7 +1,7 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z
@@ -19,7 +19,7 @@ planned_tests:
     }
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -4,7 +4,7 @@ planned_tests:
     approved_at: 2023-03-01T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-24T15:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In an actual emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -22,7 +22,7 @@ planned_tests:
     approved_at: 2023-03-01T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-24T15:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       Prawf ar Rybuddion Argyfwng yw hwn, sef gwasanaeth newydd gan lywodraeth y DU a fydd yn eich rhybuddio pan fydd argyfwng sy'n berygl i fywyd gerllaw.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -2,9 +2,9 @@ planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In an actual emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -20,9 +20,9 @@ planned_tests:
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       Prawf ar Rybuddion Argyfwng yw hwn, sef gwasanaeth newydd gan lywodraeth y DU a fydd yn eich rhybuddio pan fydd argyfwng sy'n berygl i fywyd gerllaw.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -1,7 +1,7 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z
@@ -19,7 +19,7 @@ planned_tests:
     }
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -2,9 +2,9 @@ planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In an actual emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -20,9 +20,9 @@ planned_tests:
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       Prawf ar Rybuddion Argyfwng yw hwn, sef gwasanaeth newydd gan lywodraeth y DU a fydd yn eich rhybuddio pan fydd argyfwng sy'n berygl i fywyd gerllaw.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -1,7 +1,7 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z
@@ -19,7 +19,7 @@ planned_tests:
     }
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -2,9 +2,9 @@ planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In an actual emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -20,9 +20,9 @@ planned_tests:
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
     approved_at: 2023-03-01T09:00:00Z
-    starts_at: 2023-04-23T18:00:00Z
+    starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T19:00:00Z
+    finishes_at: 2023-04-23T15:00:00Z
     content: |
       Prawf ar Rybuddion Argyfwng yw hwn, sef gwasanaeth newydd gan lywodraeth y DU a fydd yn eich rhybuddio pan fydd argyfwng sy'n berygl i fywyd gerllaw.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -1,7 +1,7 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z
@@ -19,7 +19,7 @@ planned_tests:
     }
   - id: b9ce9c12-9847-47cb-b41b-2a417ecf4ebc
     channel: severe
-    approved_at: 2023-03-01T09:00:00Z
+    approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
     finishes_at: 2023-04-23T15:00:00Z

--- a/tests/app/main/views/test_announcements.py
+++ b/tests/app/main/views/test_announcements.py
@@ -20,7 +20,7 @@ from tests import normalize_spaces
                        'search for gov.uk/alerts',
             'areas': {'names': ['Ibiza']}
         })],
-        ['Wednesday 3 February 2021', 'Ibiza'],
+        ['Wednesday 3 February 2021 at 8pm', 'Ibiza'],
         [],
         [
             'The alert will say:',
@@ -42,7 +42,7 @@ from tests import normalize_spaces
             'content': 'Paragraph 1\n\nParagraph 2',
             'areas': {'names': ['Ibiza', 'The Norfolk Broads']}
         })],
-        ['Wednesday 3 February 2021', 'Ibiza and The Norfolk Broads'],
+        ['Wednesday 3 February 2021 at 8pm', 'Ibiza and The Norfolk Broads'],
         [],
         [
             'The alert will say:',
@@ -74,7 +74,7 @@ from tests import normalize_spaces
             }),
         ],
         [
-            'Wednesday 3 February 2021', '', ''
+            'Wednesday 3 February 2021 at 8pm', '', ''
         ],
         [],
         [

--- a/tests/app/models/test_alert_date.py
+++ b/tests/app/models/test_alert_date.py
@@ -11,7 +11,6 @@ def test_AlertDate_properties():
     sample_datetime = dt_parse('2021-03-02T10:30:00Z')
     alerts_date = AlertDate(sample_datetime)
     assert alerts_date.as_lang == 'at 10:30am on Tuesday 2 March 2021'
-    assert alerts_date.as_alert_lang == 'Tuesday 2 March 2021 at 10AM'
     assert alerts_date.datetime_as_lang == 'Tuesday 2 March 2021 at 10am'
     assert alerts_date.as_iso8601 == '2021-03-02T10:30:00+00:00'
     assert alerts_date.as_utc_datetime == dt_parse('2021-03-02T10:30:00Z')
@@ -23,7 +22,6 @@ def test_AlertDate_properties_work_with_bst():
     sample_datetime = dt_parse('2021-04-20T23:30:00Z')
     alerts_date = AlertDate(sample_datetime)
     assert alerts_date.as_lang == 'at 12:30am on Wednesday 21 April 2021'
-    assert alerts_date.as_alert_lang == 'Wednesday 21 April 2021 at 12AM'
     assert alerts_date.datetime_as_lang == 'Wednesday 21 April 2021 at 12am'
     assert alerts_date.as_iso8601 == '2021-04-21T00:30:00+01:00'
     assert alerts_date.as_utc_datetime == dt_parse('2021-04-20T23:30:00Z')

--- a/tests/app/models/test_alert_date.py
+++ b/tests/app/models/test_alert_date.py
@@ -11,7 +11,8 @@ def test_AlertDate_properties():
     sample_datetime = dt_parse('2021-03-02T10:30:00Z')
     alerts_date = AlertDate(sample_datetime)
     assert alerts_date.as_lang == 'at 10:30am on Tuesday 2 March 2021'
-    assert alerts_date.as_alert_lang == 'Tuesday 2 March 2021, at 10AM'
+    assert alerts_date.as_alert_lang == 'Tuesday 2 March 2021 at 10AM'
+    assert alerts_date.datetime_as_lang == 'Tuesday 2 March 2021 at 10am'
     assert alerts_date.as_iso8601 == '2021-03-02T10:30:00+00:00'
     assert alerts_date.as_utc_datetime == dt_parse('2021-03-02T10:30:00Z')
     assert alerts_date.as_local_datetime == dt_parse('2021-03-02T10:30:00Z')
@@ -22,7 +23,8 @@ def test_AlertDate_properties_work_with_bst():
     sample_datetime = dt_parse('2021-04-20T23:30:00Z')
     alerts_date = AlertDate(sample_datetime)
     assert alerts_date.as_lang == 'at 12:30am on Wednesday 21 April 2021'
-    assert alerts_date.as_alert_lang == 'Wednesday 21 April 2021, at 12AM'
+    assert alerts_date.as_alert_lang == 'Wednesday 21 April 2021 at 12AM'
+    assert alerts_date.datetime_as_lang == 'Wednesday 21 April 2021 at 12am'
     assert alerts_date.as_iso8601 == '2021-04-21T00:30:00+01:00'
     assert alerts_date.as_utc_datetime == dt_parse('2021-04-20T23:30:00Z')
     assert alerts_date.as_local_datetime == dt_parse('2021-04-21T00:30:00+01:00')


### PR DESCRIPTION
To add the time to the landing page banner and announcement page, the following changes were made:

- Add a method to convert the meridiem indicator to lowercase
- Use new alert_date method to display date & time in banner and announcement templates
- Update alert-date and announcements test files to reflect the extra 'time' text
- Update planned test times in the dev, preview, staging and prod YAML files (in UTC)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
