### PR TITLE
NTM Announcement Expiry

### DIFF
--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -58,8 +58,7 @@
     {% if alerts.current_and_public %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ banner(alerts.current_and_public | length, alerts.last_updated_date, lang='cy') }}
-    {% endif %}
-    {% if alerts.dates_of_planned_test_alerts %}
+    {% elif alerts.dates_of_planned_test_alerts %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ national_test_banner(alerts.dates_of_planned_test_alerts, lang='cy') }}
     {% endif %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -57,8 +57,7 @@
     {% if alerts.current_and_public %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
-    {% endif %}
-    {% if alerts.dates_of_planned_test_alerts %}
+    {% elif alerts.dates_of_planned_test_alerts %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ national_test_banner(alerts.dates_of_planned_test_alerts) }}
     {% endif %}

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -4,7 +4,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In a real emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -22,7 +22,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       Prawf o wasanaeth Rhybuddion Argyfwng Llywodraeth y DU yw hwn. Bydd yn eich rhybuddio os oes argyfwng gerllaw sy'n peryglu bywyd.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -4,7 +4,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In a real emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -22,7 +22,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       Prawf o wasanaeth Rhybuddion Argyfwng Llywodraeth y DU yw hwn. Bydd yn eich rhybuddio os oes argyfwng gerllaw sy'n peryglu bywyd.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -4,7 +4,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In a real emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -22,7 +22,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       Prawf o wasanaeth Rhybuddion Argyfwng Llywodraeth y DU yw hwn. Bydd yn eich rhybuddio os oes argyfwng gerllaw sy'n peryglu bywyd.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -4,7 +4,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       This is a test of Emergency Alerts, a new UK government service that will warn you if there’s a life-threatening emergency nearby.
       In a real emergency, follow the instructions in the alert to keep yourself and others safe.
@@ -22,7 +22,7 @@ planned_tests:
     approved_at: 2023-04-06T09:00:00Z
     starts_at: 2023-04-23T14:00:00Z
     cancelled_at:
-    finishes_at: 2023-04-23T15:00:00Z
+    finishes_at: 2023-04-23T14:05:00Z
     content: |
       Prawf o wasanaeth Rhybuddion Argyfwng Llywodraeth y DU yw hwn. Bydd yn eich rhybuddio os oes argyfwng gerllaw sy'n peryglu bywyd.
       Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.


### PR DESCRIPTION
Expires the announcement at 3:05. Announcements are also superseded in the status box by current alerts, meaning that the announcement will be hidden for the remainder of time that it remains in the site, before being stripped out when the alert is taken down (presumably after 3:05)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
