### PR TITLE
Complete removal of MNO test display

### DIFF
--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -75,10 +75,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gweill",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           },

--- a/app/templates/views/announcements.html
+++ b/app/templates/views/announcements.html
@@ -75,10 +75,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/app/templates/views/current-alerts.cy.html
+++ b/app/templates/views/current-alerts.cy.html
@@ -81,10 +81,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gwasanaeth",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion yn y gorffennol",
             "href": "/alerts/past-alerts.cy"
           }

--- a/app/templates/views/current-alerts.html
+++ b/app/templates/views/current-alerts.html
@@ -81,10 +81,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Past alerts",
             "href": "/alerts/past-alerts"
           }

--- a/app/templates/views/how-alerts-work.cy.html
+++ b/app/templates/views/how-alerts-work.cy.html
@@ -156,10 +156,6 @@
             "href": "/alerts/about.cy"
           },
           {
-            "text": "Profion ar y gwasanaeth",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           },

--- a/app/templates/views/how-alerts-work.html
+++ b/app/templates/views/how-alerts-work.html
@@ -156,10 +156,6 @@
             "href": "/alerts"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -169,10 +169,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gwasanaeth",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           },

--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -54,17 +54,13 @@
       }) }}
     </div>
   </div>
-  {% if alerts.current_and_public or alerts.dates_of_current_and_planned_test_alerts or alerts.dates_of_planned_test_alerts %}
+  {% if alerts.current_and_public or alerts.dates_of_planned_test_alerts %}
     {% if alerts.current_and_public %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ banner(alerts.current_and_public | length, alerts.last_updated_date, lang='cy') }}
     {% elif alerts.dates_of_planned_test_alerts %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ national_test_banner(alerts.dates_of_planned_test_alerts, lang='cy') }}
-    {% endif %}
-    {% if alerts.dates_of_current_and_planned_test_alerts %}
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      {{ service_tests_banner(alerts.dates_of_current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts, lang='cy') }}
     {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -168,10 +168,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -53,17 +53,13 @@
       }) }}
     </div>
   </div>
-  {% if alerts.current_and_public or alerts.dates_of_current_and_planned_test_alerts or alerts.dates_of_planned_test_alerts %}
+  {% if alerts.current_and_public or alerts.dates_of_planned_test_alerts %}
     {% if alerts.current_and_public %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ banner(alerts.current_and_public | length, alerts.last_updated_date) }}
     {% elif alerts.dates_of_planned_test_alerts %}
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       {{ national_test_banner(alerts.dates_of_planned_test_alerts) }}
-    {% endif %}
-    {% if alerts.dates_of_current_and_planned_test_alerts %}
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      {{ service_tests_banner(alerts.dates_of_current_and_planned_test_alerts | length, alerts.dates_of_current_and_planned_test_alerts) }}
     {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/templates/views/past-alerts.cy.html
+++ b/app/templates/views/past-alerts.cy.html
@@ -87,10 +87,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gwasanaeth",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           }

--- a/app/templates/views/past-alerts.html
+++ b/app/templates/views/past-alerts.html
@@ -87,10 +87,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           }

--- a/app/templates/views/planned-tests.cy.html
+++ b/app/templates/views/planned-tests.cy.html
@@ -75,10 +75,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gweill",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           },

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -75,10 +75,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -285,10 +285,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/app/templates/views/service-tests.cy.html
+++ b/app/templates/views/service-tests.cy.html
@@ -52,16 +52,9 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if alerts.planned_non_public_grouped_by_date %}
-        {% for _date, alerts_or_planned_tests in alerts.planned_non_public_grouped_by_date | sort %}
-          {% set date_loop = loop %}
-          {{ planned_tests_by_date(date_loop, alerts_or_planned_tests) }}
-        {% endfor %}
-      {% else %}
-        <p class="govuk-body">
-          Ar hyn o bryd does dim profion ar y gwasanaeth.
-        </p>
-      {% endif %}
+      <p class="govuk-body">
+        Ar hyn o bryd does dim profion ar y gwasanaeth.
+      </p>
     </div>
     <div class="govuk-grid-column-one-third">
       {{ related_content({

--- a/app/templates/views/service-tests.html
+++ b/app/templates/views/service-tests.html
@@ -52,16 +52,9 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if alerts.planned_non_public_grouped_by_date %}
-        {% for _date, alerts_or_planned_tests in alerts.planned_non_public_grouped_by_date | sort %}
-          {% set date_loop = loop %}
-          {{ planned_tests_by_date(date_loop, alerts_or_planned_tests) }}
-        {% endfor %}
-      {% else %}
-        <p class="govuk-body">
-          There are currently no service tests.
-        </p>
-      {% endif %}
+      <p class="govuk-body">
+        There are currently no service tests.
+      </p>
     </div>
     <div class="govuk-grid-column-one-third">
       {{ related_content({

--- a/app/templates/views/system-testing.cy.html
+++ b/app/templates/views/system-testing.cy.html
@@ -89,10 +89,6 @@
             "href": "/alerts/how-alerts-work.cy"
           },
           {
-            "text": "Profion ar y gwasanaeth",
-            "href": "/alerts/service-tests.cy"
-          },
-          {
             "text": "Rhybuddion ar hyn o bryd",
             "href": "/alerts/current-alerts.cy"
           },

--- a/app/templates/views/system-testing.html
+++ b/app/templates/views/system-testing.html
@@ -89,10 +89,6 @@
             "href": "/alerts/how-alerts-work"
           },
           {
-            "text": "Service tests",
-            "href": "/alerts/service-tests"
-          },
-          {
             "text": "Current alerts",
             "href": "/alerts/current-alerts"
           },

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -4,7 +4,6 @@ import hashlib
 import pytest
 
 from app.models.planned_test import PlannedTest
-from tests import normalize_spaces
 from tests.conftest import create_planned_test_dict
 
 
@@ -33,65 +32,6 @@ def test_index_page_shows_current_alerts(
     assert '1 current alert' in html.text
     # Test alerts should not show on homepage when there is a current alert
     assert 'service test' not in html.select_one('main h2').text.lower()
-
-
-@pytest.mark.parametrize('current_and_planned_test_alerts, expected_banner', (
-    ([
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-02-03T00:00:00Z'
-        ))
-    ], (
-        '1 service test '
-        'Wednesday 3 February 2021'
-    )),
-    ([
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-02-03T00:00:00Z'
-        )),
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-06-03T00:00:00Z'
-        )),
-    ], (
-        '2 service tests '
-        'Wednesday 3 February 2021 and Thursday 3 June 2021'
-    )),
-    ([
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-02-03T00:00:00Z'
-        )),
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-06-03T00:00:00Z'
-        )),
-        PlannedTest(create_planned_test_dict(
-            starts_at='2021-06-03T23:00:01Z'
-        )),
-    ], (
-        '3 service tests '
-        'Wednesday 3 February 2021 to Friday 4 June 2021'
-    )),
-))
-def test_index_page_shows_planned_tests(
-    client_get,
-    mocker,
-    current_and_planned_test_alerts,
-    expected_banner,
-):
-    mocker.patch('app.models.alerts.Alerts.current_and_public', [])
-    mocker.patch(
-        'app.models.alerts.Alerts.current_and_planned_test_alerts',
-        current_and_planned_test_alerts,
-    )
-
-    html = client_get("alerts")
-    assert normalize_spaces(
-        html.select_one('.alerts-notification-banner').text
-    ) == (
-        expected_banner
-    )
-
-    assert html.select_one('.alerts-notification-banner a')['href'] == (
-        '/alerts/service-tests'
-    )
 
 
 def test_index_page_content_security_policy_sha(client_get):

--- a/tests/app/main/views/test_service_tests.py
+++ b/tests/app/main/views/test_service_tests.py
@@ -1,4 +1,3 @@
-import pytest
 from dateutil.parser import parse as dt_parse
 from freezegun import freeze_time
 
@@ -15,53 +14,6 @@ def test_planned_tests_page(mocker, client_get):
         normalize_spaces(p.text) for p in html.select('main p')
     ] == [
         'There are currently no service tests.'
-    ]
-
-
-@pytest.mark.parametrize('extra_json_fields', (
-    # Doesn’t matter if the alert is still active…
-    {},
-    # Or if it’s cancelled before now
-    {'cancelled_at': dt_parse('2021-04-21T11:00:00Z')},
-    # Or if it’s finished already
-    {'finishes_at': dt_parse('2021-04-21T11:00:00Z')},
-))
-@freeze_time('2021-04-21T10:00:00Z')
-def test_planned_tests_page_with_current_operator_test(
-    mocker,
-    client_get,
-    extra_json_fields,
-):
-    mocker.patch('app.models.alerts.PlannedTests.from_yaml', return_value=[])
-    mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([
-        create_alert_dict(
-            channel='operator',
-            starts_at=dt_parse('2021-04-21T09:00:00Z'),
-            content='This is a mobile network operator test of the Emergency Alerts '
-                    'service. You do not need to take any action. To find out more, '
-                    'search for gov.uk/alerts',
-            **extra_json_fields
-        )
-    ]))
-    html = client_get("alerts/service-tests")
-    assert [
-        normalize_spaces(h2.text) for h2 in html.select('.govuk-grid-column-two-thirds h2')
-    ] == [
-        'Wednesday 21 April 2021', ''
-    ]
-    assert not html.select('main h3')
-    assert [
-        normalize_spaces(p.text) for p in html.select('.govuk-grid-column-two-thirds p')
-    ] == [
-        'There will be a service test of the UK Emergency Alerts system today.',
-        'Most mobile phones and tablets will not get a test alert.',
-        'Find out more about testing the Emergency Alerts service.',
-        'The alert will say:',
-        (
-            'This is a mobile network operator test of the Emergency Alerts '
-            'service. You do not need to take any action. To find out more, '
-            'search for gov.uk/alerts'
-        ),
     ]
 
 


### PR DESCRIPTION
Complete removal of MNO test display on frontend.
Note this has mostly been stripping out of components that will display MNO tests from the jinja, and removal of tests that specifically checked for the presence of MNO tests. This should be a temporary fix.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
