### PR TITLE
EAS-1005 Add script for starting govuk-alerts celery worker

### DIFF
--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 # Build the image with the following commands
-# gds aws cell-broadcast-development-admin bash ./scripts/docker-build.sh --ENVIRONMENT development --IMAGE <image-name> --ARGS '--load'
+# gds aws cell-broadcast-development-admin bash ./scripts/docker-build.sh --IMAGE <image-name> --ARGS '--load'
 # where <args> can be '--load' (import built image into local docker cache) or '--push' (push built image out to AWS ECR)
 
 ARG DEBIAN_FRONTEND='noninteractive'
@@ -38,6 +38,8 @@ COPY . $GOVUK_DIR
 
 # Build emergency-alerts-api
 RUN $PYTHON_VERSION -m venv $VENV_GOVUK && . $VENV_GOVUK/bin/activate && pip3 install pycurl && cd $GOVUK_DIR && make bootstrap
+
+RUN useradd -ms /bin/bash easuser && chown -R easuser:easuser $GOVUK_DIR
 
 CMD cd $GOVUK_DIR && . $VENV_GOVUK/bin/activate && export FLASK_ENV=development && flask run -p 6017 --host=0.0.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,18 @@ freeze-requirements: ## create static requirements.txt
 	pip install --upgrade pip-tools
 	pip-compile requirements.in
 
+.PHONY: run-celery
+run-celery: ## Run celery
+	. environment.sh && celery \
+		-A run_celery.notify_celery worker \
+		--uid=$(shell id -u easuser) \
+		--pidfile=/tmp/celery.pid \
+		--prefetch-multiplier=1 \
+		--loglevel=INFO \
+		--concurrency=1 \
+		--autoscale=1,1
+		--hostname=0.0.0.0
+
 .PHONY: cf-login
 cf-login: ## Log in to Cloud Foundry
 	$(if ${CF_USERNAME},,$(error Must specify CF_USERNAME))

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run-celery: ## Run celery
 		--uid=$(shell id -u easuser) \
 		--pidfile=/tmp/celery.pid \
 		--prefetch-multiplier=1 \
-		--loglevel=INFO \
+		--loglevel=WARNING \
 		--concurrency=1 \
 		--autoscale=1,1
 		--hostname=0.0.0.0

--- a/app/config.py
+++ b/app/config.py
@@ -8,21 +8,21 @@ class Config():
     NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
     QUEUE_NAME = "govuk-alerts"
 
-    NOTIFY_APP_NAME = 'govuk-alerts'
-    AWS_REGION = 'eu-west-2'
-    NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH', 'application.log')
+    NOTIFY_APP_NAME = "govuk-alerts"
+    AWS_REGION = "eu-west-2"
+    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH", "application.log")
 
     BROADCASTS_AWS_ACCESS_KEY_ID = os.getenv("BROADCASTS_AWS_ACCESS_KEY_ID")
     BROADCASTS_AWS_SECRET_ACCESS_KEY = os.getenv("BROADCASTS_AWS_SECRET_ACCESS_KEY")
-    BROADCASTS_AWS_REGION = 'eu-west-2'
+    BROADCASTS_AWS_REGION = "eu-west-2"
     GOVUK_ALERTS_S3_BUCKET_NAME = os.getenv("GOVUK_ALERTS_S3_BUCKET_NAME")
 
     FASTLY_SERVICE_ID = os.getenv("FASTLY_SERVICE_ID")
     FASTLY_API_KEY = os.getenv("FASTLY_API_KEY")
-    FASTLY_SURROGATE_KEY = 'notify-emergency-alerts'
+    FASTLY_SURROGATE_KEY = "notify-emergency-alerts"
 
-    NOTIFY_API_HOST_NAME = os.environ.get('NOTIFY_API_HOST_NAME')
-    NOTIFY_API_CLIENT_SECRET = os.environ.get('NOTIFY_API_CLIENT_SECRET')
+    NOTIFY_API_HOST_NAME = os.environ.get("NOTIFY_API_HOST_NAME")
+    NOTIFY_API_CLIENT_SECRET = os.environ.get("NOTIFY_API_CLIENT_SECRET")
     NOTIFY_API_CLIENT_ID = "govuk-alerts"
 
     CELERY = {
@@ -36,17 +36,17 @@ class Config():
             "task_acks_late": True,
         },
         "timezone": "UTC",
-        'imports': ['app.celery.tasks'],
-        'task_queues': [
-            Queue(QUEUE_NAME, Exchange('default'), routing_key=QUEUE_NAME)
+        "imports": ["app.celery.tasks"],
+        "task_queues": [
+            Queue(QUEUE_NAME, Exchange("default"), routing_key=QUEUE_NAME)
         ],
         # Restart workers after a few tasks have been executed - this will help prevent any memory leaks
         # (not that we should be encouraging sloppy memory management). Although the tasks are time-critical,
         # we don't expect to get them in quick succession, so a small restart delay is acceptable.
-        'worker_max_tasks_per_child': 10
+        "worker_max_tasks_per_child": 10
     }
 
-    STATSD_HOST = os.getenv('STATSD_HOST')
+    STATSD_HOST = os.getenv("STATSD_HOST")
     STATSD_PORT = 8125
     STATSD_ENABLED = bool(STATSD_HOST)
 
@@ -81,9 +81,9 @@ class Preview(Config):
 
 
 configs = {
-    'development': Development,
-    'test': Test,
-    'staging': Staging,
-    'preview': Preview,
-    'production': Config,
+    "development": Development,
+    "test": Test,
+    "staging": Staging,
+    "preview": Preview,
+    "production": Config,
 }

--- a/app/config.py
+++ b/app/config.py
@@ -5,10 +5,10 @@ from kombu import Exchange, Queue
 
 class Config():
     NOTIFICATION_QUEUE_PREFIX = os.getenv('NOTIFICATION_QUEUE_PREFIX')
-    QUEUE_NAME = 'govuk-alerts'
+    QUEUE_NAME = "govuk-alerts"
 
     NOTIFY_APP_NAME = 'govuk-alerts'
-    NOTIFY_AWS_REGION = 'eu-west-1'
+    AWS_REGION = 'eu-west-2'
     NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH', 'application.log')
 
     BROADCASTS_AWS_ACCESS_KEY_ID = os.getenv("BROADCASTS_AWS_ACCESS_KEY_ID")
@@ -25,14 +25,16 @@ class Config():
     NOTIFY_API_CLIENT_ID = "govuk-alerts"
 
     CELERY = {
-        'broker_url': 'sqs://',
-        'broker_transport_options': {
-            'region': NOTIFY_AWS_REGION,
-            'visibility_timeout': 310,
-            'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX,
-            'wait_time_seconds': 20,  # enable long polling, with a wait time of 20 seconds
+        "broker_url": "https://sqs.eu-west-2.amazonaws.com",
+        "broker_transport": "sqs",
+        "broker_transport_options": {
+            "region": AWS_REGION,
+            "visibility_timeout": 310,
+            "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+            "is_secure": True,
+            "task_acks_late": True,
         },
-        'timezone': 'Europe/London',
+        "timezone": "UTC",
         'imports': ['app.celery.tasks'],
         'task_queues': [
             Queue(QUEUE_NAME, Exchange('default'), routing_key=QUEUE_NAME)
@@ -40,7 +42,7 @@ class Config():
         # Restart workers after a few tasks have been executed - this will help prevent any memory leaks
         # (not that we should be encouraging sloppy memory management). Although the tasks are time-critical,
         # we don't expect to get them in quick succession, so a small restart delay is acceptable.
-        'worker_max_tasks_per_child': 20
+        'worker_max_tasks_per_child': 10
     }
 
     STATSD_HOST = os.getenv('STATSD_HOST')

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,7 @@ class Config():
         "task_queues": [
             Queue(QUEUE_NAME, Exchange("default"), routing_key=QUEUE_NAME)
         ],
+        "worker_log_format": "[%(levelname)s] %(message)s",
         # Restart workers after a few tasks have been executed - this will help prevent any memory leaks
         # (not that we should be encouraging sloppy memory management). Although the tasks are time-critical,
         # we don't expect to get them in quick succession, so a small restart delay is acceptable.

--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,8 @@ from kombu import Exchange, Queue
 
 
 class Config():
-    NOTIFICATION_QUEUE_PREFIX = os.getenv('NOTIFICATION_QUEUE_PREFIX')
+    # Prefix to identify queues in SQS
+    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
     QUEUE_NAME = "govuk-alerts"
 
     NOTIFY_APP_NAME = 'govuk-alerts'

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+echo "Start script executing for govuk-alerts celery worker..."
+
+function configure_container_role(){
+  aws configure set default.region eu-west-2
+}
+
+function run_celery(){
+  cd $API_DIR;
+  . $VENV_API/bin/activate && make run-celery &
+}
+
+configure_container_role
+run_celery


### PR DESCRIPTION
The AWS environments will need an instance that runs a celery worker to handle messages on the `<env>-govuk-alerts` SQS queue.

This PR should not be merged until we have the Gov.uk/Alerts pipeline fully operational. Test can be accomplished by tagging the commit of this PR and running the pipeline manually to deploy to the required environment.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
