### PR TITLE
Change makefile command to use pip3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run-flask:
 
 .PHONY: bootstrap
 bootstrap:
-	pip install -r requirements_for_test.txt
+	pip3 install -r requirements_for_test.txt
 	source $(HOME)/.nvm/nvm.sh && nvm install && npm ci --no-audit && npm run build
 
 .PHONY: npm-audit


### PR DESCRIPTION
To avoid version ambiguity, use pip3 in the Makefile

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
