### PR TITLE
EAS-1005 Revert config to fix concourse pipelines

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,12 +4,57 @@ from kombu import Exchange, Queue
 
 
 class Config():
+    NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")
+    QUEUE_NAME = "govuk-alerts"
+
+    NOTIFY_APP_NAME = "govuk-alerts"
+    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH", "application.log")
+
+    BROADCASTS_AWS_ACCESS_KEY_ID = os.getenv("BROADCASTS_AWS_ACCESS_KEY_ID")
+    BROADCASTS_AWS_SECRET_ACCESS_KEY = os.getenv("BROADCASTS_AWS_SECRET_ACCESS_KEY")
+    BROADCASTS_AWS_REGION = "eu-west-2"
+    GOVUK_ALERTS_S3_BUCKET_NAME = os.getenv("GOVUK_ALERTS_S3_BUCKET_NAME")
+
+    FASTLY_SERVICE_ID = os.getenv("FASTLY_SERVICE_ID")
+    FASTLY_API_KEY = os.getenv("FASTLY_API_KEY")
+    FASTLY_SURROGATE_KEY = "notify-emergency-alerts"
+
+    NOTIFY_API_HOST_NAME = os.environ.get("NOTIFY_API_HOST_NAME")
+    NOTIFY_API_CLIENT_SECRET = os.environ.get("NOTIFY_API_CLIENT_SECRET")
+    NOTIFY_API_CLIENT_ID = "govuk-alerts"
+
+    CELERY = {
+        "broker_url": "sqs://",
+        "broker_transport_options": {
+            "region": "eu-west-1",
+            "visibility_timeout": 310,
+            "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
+            "wait_time_seconds": 20,  # enable long polling, with a wait time of 20 seconds
+        },
+        "timezone": "Europe/London",
+        "imports": ["app.celery.tasks"],
+        "task_queues": [
+            Queue(QUEUE_NAME, Exchange("default"), routing_key=QUEUE_NAME)
+        ],
+        # Restart workers after a few tasks have been executed - this will help prevent any memory leaks
+        # (not that we should be encouraging sloppy memory management). Although the tasks are time-critical,
+        # we don't expect to get them in quick succession, so a small restart delay is acceptable.
+        "worker_max_tasks_per_child": 20
+    }
+
+    STATSD_HOST = os.getenv("STATSD_HOST")
+    STATSD_PORT = 8125
+    STATSD_ENABLED = bool(STATSD_HOST)
+
+    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests.yaml"
+
+
+class Decoupled(Config):
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
     QUEUE_NAME = "govuk-alerts"
 
     NOTIFY_APP_NAME = "govuk-alerts"
-    AWS_REGION = "eu-west-2"
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH", "application.log")
 
     BROADCASTS_AWS_ACCESS_KEY_ID = os.getenv("BROADCASTS_AWS_ACCESS_KEY_ID")
@@ -29,7 +74,7 @@ class Config():
         "broker_url": "https://sqs.eu-west-2.amazonaws.com",
         "broker_transport": "sqs",
         "broker_transport_options": {
-            "region": AWS_REGION,
+            "region": "eu-west-2",
             "visibility_timeout": 310,
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
             "is_secure": True,
@@ -83,6 +128,7 @@ class Preview(Config):
 
 configs = {
     "development": Development,
+    "decoupled": Decoupled,
     "test": Test,
     "staging": Staging,
     "preview": Preview,


### PR DESCRIPTION
The original config needs to be restored to maintain compatibility with the Concourse pipelines until such time that we can move away from Concourse completely.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
