### PR TITLE
adding flask publish to start script

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 PyYAML==5.4.1
 boto3==1.20.26
-celery==5.1.2
+celery==5.2.7
 Flask==1.1.2
 pycurl==7.43.0.6
 awscli-cwlogs>=1.4,<1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ botocore==1.23.26
     #   s3transfer
 cachetools==5.0.0
     # via emergency-alerts-utils
-celery==5.1.2
+celery==5.2.7
     # via -r requirements.in
 certifi==2021.10.8
     # via
@@ -31,7 +31,7 @@ certifi==2021.10.8
     #   requests
 charset-normalizer==2.0.9
     # via requests
-click==7.1.2
+click==8.1.3
     # via
     #   celery
     #   click-didyoumean
@@ -170,6 +170,3 @@ werkzeug==2.0.2
     # via flask
 wrapt==1.13.3
     # via deprecated
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -11,5 +11,11 @@ function run_celery(){
   . $VENV_API/bin/activate && make run-celery &
 }
 
+function flask_publish(){
+  cd $GOVUK_DIR;
+  . $VENV_GOVUK/bin/activate && flask publish-with-assets
+}
+
 configure_container_role
 run_celery
+flask_publish

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -7,8 +7,8 @@ function configure_container_role(){
 }
 
 function run_celery(){
-  cd $API_DIR;
-  . $VENV_API/bin/activate && make run-celery &
+  cd $GOVUK_DIR;
+  . $GOVUK_DIR/bin/activate && make run-celery &
 }
 
 function flask_publish(){


### PR DESCRIPTION
Adding flask publish-with-assets to start script of the govuk ECS service

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
