### PR TITLE
EAS-1070 Upload assets with mime_type metadata

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -1,5 +1,4 @@
 import click
-# from app.celery.tasks import publish_govuk_alerts
 from flask import cli, current_app
 
 from app.models.alerts import Alerts


### PR DESCRIPTION
Assets should be uploaded to S3 with mime type metadata so the server knows what to do with them.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
