### PR TITLE
removing tag functionality from build pipeline

### DIFF
--- a/.codepipeline/buildspec-govuk-build.yml
+++ b/.codepipeline/buildspec-govuk-build.yml
@@ -3,8 +3,6 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo Checking out to govuk_${ENVIRONMENT}_latest tag...
-      - git checkout tags/govuk_${ENVIRONMENT}_latest
       - echo Logging in to Amazon ECR...
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS
         --password-stdin $ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com


### PR DESCRIPTION
Removing checking out to latest tag within the build step of code pipeline

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
