### PR TITLE
EAS-1070 Fix asset mime types

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -1,5 +1,4 @@
 import click
-# from app.celery.tasks import publish_govuk_alerts
 from flask import cli, current_app
 
 from app.models.alerts import Alerts

--- a/app/utils.py
+++ b/app/utils.py
@@ -99,6 +99,8 @@ def upload_assets_to_s3():
     assets = get_asset_files(DIST)
     for filename, (content, mimetype) in assets.items():
         current_app.logger.info("Uploading " + filename)
+        if mimetype == "application/javascript":
+            mimetype = "text/javascript"
         s3.put_object(
             Body=content,
             Bucket=bucket_name,
@@ -130,12 +132,13 @@ def get_asset_files(folder):
         s3path = root[root.find("alerts/"):]
 
         # ignore hidden files and folders and javascript debug maps
-        files = [f for f in files if (not f[0] == '.' and not f[-6:] == 'js.map')]
+        files = [f for f in files if (not f[0] == "." and not f[-6:] == "js.map")]
 
         for file in files:
             filename = root + "/" + file
             s3name = s3path + "/" + file
-            with open(filename, "rb") as f:
+            mode = "r" if file[-3:] == "css" or file[-2:] == "js" else "rb"
+            with open(filename, mode) as f:
                 contents = f.read()
                 mime_type, _ = mimetypes.guess_type(filename)
                 assets[s3name] = (contents, mime_type)


### PR DESCRIPTION
- Different file types should be read with different encodings
- Python's mime_type parser uses a legacy type (application/javascript); this is changed to text/javascript on the fly

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
