### PR TITLE
EAS-1070 Handle mimetypes in govuk-alerts

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,3 @@
-import mimetypes
 import os
 import re
 from pathlib import Path
@@ -138,9 +137,22 @@ def get_asset_files(folder):
             mode = "r" if file[-3:] == "css" or file[-2:] == "js" else "rb"
             with open(filename, mode) as f:
                 contents = f.read()
-                mime_type, _ = mimetypes.guess_type(filename)
-                if mime_type == "application/javascript":
-                    mime_type = "text/javascript"
+                mime_type = mimetype_from_extension(file.split(".")[-1])
                 assets[s3name] = (contents, mime_type)
 
     return assets
+
+
+mimetype_from_extension = {
+    "html": "text/html",
+    "css": "text/css",
+    "ico": "image/x-icon",
+    "jpg": "image/jpeg",
+    "js": "application/javascript",
+    "map": "application/javascript",
+    "png": "image/png",
+    "svg": "image/svg+xml",
+    "webp": "image/webp",
+    "woff": "font/woff",
+    "woff2": "font/woff2",
+}

--- a/app/utils.py
+++ b/app/utils.py
@@ -128,8 +128,8 @@ def get_asset_files(folder):
     for root, _, files in os.walk(folder):
         s3path = root[root.find("alerts/"):]
 
-        # ignore hidden files and folders and javascript debug maps
-        files = [f for f in files if (not f[0] == "." and not f[-6:] == "js.map")]
+        # ignore hidden files and folders
+        files = [f for f in files if not f[0] == "."]
 
         for file in files:
             filename = root + "/" + file
@@ -137,7 +137,7 @@ def get_asset_files(folder):
             mode = "r" if file[-3:] == "css" or file[-2:] == "js" else "rb"
             with open(filename, mode) as f:
                 contents = f.read()
-                mime_type = mimetype_from_extension(file.split(".")[-1])
+                mime_type = mimetype_from_extension[file.split(".")[-1]]
                 assets[s3name] = (contents, mime_type)
 
     return assets


### PR DESCRIPTION
The native python 3.9 mimetype package doesn't handle all file types in the govuk-alerts application. This PR implements a simple custom mapper, covering the file types found in the /dist folder.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
