### PR TITLE
Make relative links to paths outside of /alerts absolute

### DIFF
--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -66,11 +66,11 @@
         },
         {
           'text': 'Accessibility statement',
-          'href': 'www.gov.uk/help/accessibility-statement'
+          'href': 'https://www.gov.uk/help/accessibility-statement'
         },
         {
           'text': 'Terms and conditions',
-          'href': 'www.gov.uk/help/terms-conditions'
+          'href': 'https://www.gov.uk/help/terms-conditions'
         }
       ]
     }

--- a/app/templates/_layout.html
+++ b/app/templates/_layout.html
@@ -66,11 +66,11 @@
         },
         {
           'text': 'Accessibility statement',
-          'href': '/help/accessibility-statement'
+          'href': 'www.gov.uk/help/accessibility-statement'
         },
         {
           'text': 'Terms and conditions',
-          'href': '/help/terms-conditions'
+          'href': 'www.gov.uk/help/terms-conditions'
         }
       ]
     }

--- a/app/templates/views/404.html
+++ b/app/templates/views/404.html
@@ -32,11 +32,11 @@
         },
         {
           'text': 'Accessibility statement',
-          'href': '/help/accessibility-statement'
+          'href': 'www.gov.uk/help/accessibility-statement'
         },
         {
           'text': 'Terms and conditions',
-          'href': '/help/terms-conditions'
+          'href': 'www.gov.uk/help/terms-conditions'
         }
       ]
     }

--- a/app/templates/views/404.html
+++ b/app/templates/views/404.html
@@ -32,11 +32,11 @@
         },
         {
           'text': 'Accessibility statement',
-          'href': 'www.gov.uk/help/accessibility-statement'
+          'href': 'https://www.gov.uk/help/accessibility-statement'
         },
         {
           'text': 'Terms and conditions',
-          'href': 'www.gov.uk/help/terms-conditions'
+          'href': 'https://www.gov.uk/help/terms-conditions'
         }
       ]
     }

--- a/app/templates/views/alert.cy.html
+++ b/app/templates/views/alert.cy.html
@@ -34,7 +34,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/alert.html
+++ b/app/templates/views/alert.html
@@ -34,7 +34,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/announcements.html
+++ b/app/templates/views/announcements.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/current-alerts.cy.html
+++ b/app/templates/views/current-alerts.cy.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/current-alerts.html
+++ b/app/templates/views/current-alerts.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/how-alerts-work.cy.html
+++ b/app/templates/views/how-alerts-work.cy.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/how-alerts-work.html
+++ b/app/templates/views/how-alerts-work.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -32,7 +32,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       }
     ]
   }) }}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -31,7 +31,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       }
     ]
   }) }}

--- a/app/templates/views/past-alerts.cy.html
+++ b/app/templates/views/past-alerts.cy.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/past-alerts.html
+++ b/app/templates/views/past-alerts.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/planned-tests.cy.html
+++ b/app/templates/views/planned-tests.cy.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/planned-tests.html
+++ b/app/templates/views/planned-tests.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -14,7 +14,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/service-tests.cy.html
+++ b/app/templates/views/service-tests.cy.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/service-tests.html
+++ b/app/templates/views/service-tests.html
@@ -24,7 +24,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",

--- a/app/templates/views/system-testing.cy.html
+++ b/app/templates/views/system-testing.cy.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "Am Rybuddion Argyfwng",

--- a/app/templates/views/system-testing.html
+++ b/app/templates/views/system-testing.html
@@ -29,7 +29,7 @@
     "items": [
       {
         "text": "Home",
-        "href": "/"
+        "href": "https://www.gov.uk/"
       },
       {
         "text": "About Emergency Alerts",


### PR DESCRIPTION
Make relative links to paths outside of /alerts absolute, given that we're no longer running on infrastructure that will allow us to make relative links to gov.uk.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
