### PR TITLE
EAS-914 EAS-1081 Privacy Notice update

### DIFF
--- a/app/assets/stylesheets/_extensions.scss
+++ b/app/assets/stylesheets/_extensions.scss
@@ -20,3 +20,11 @@
   margin-bottom: 30px;
   margin-top: 30px;
 }
+
+.govuk-body-metadata {
+  @include govuk-text-colour;
+  @include govuk-font($size: 16);
+
+  margin-bottom: 50px;
+  margin-top: -30px;
+}

--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -30,7 +30,7 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
-      <p class="govuk-body-s">
+      <p class="govuk-body-metadata">
         Last updated 24 May 2023
       </p>
     </div>

--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -198,7 +198,7 @@
         SK9 5AF
       </p>
       <p class="govuk-body">
-        Email: <a class="govuk-link" href="https://www.gov.uk/alerts/casework@ico.org.uk">casework@ico.org.uk</a><br>
+        Email: <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
         Telephone: 0303 123 1113<br>
         Textphone: 01625 545860<br>
         Monday to Friday, 9am to 4:30pm<br>

--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -3,7 +3,7 @@
 {%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
 {%- from "components/related_content.html" import related_content -%}
 
-{% set pageTitle = "Emergency Alerts privacy notice" %}
+{% set pageTitle = "Privacy notice: How we use your data" %}
 
 {% block pageTitleCurrent -%}
   {{ pageTitle }}
@@ -30,107 +30,55 @@
       <h1 class="govuk-heading-xl">
         {{ pageTitle }}
       </h1>
+      <p class="govuk-body-s">
+        Last updated 24 May 2023
+      </p>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        This privacy notice relates to the:
-      </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Emergency Alerts service</li>
-          <li>gov.uk/alerts website</li>
-          <li>user feedback about the Emergency Alerts service and guidance</li>
-        </ul>
-      <p class="govuk-body">
-        It explains what personal data we collect and what we do with it. It also explains your rights and how to enforce them.
-      </p>
       <h2 class="govuk-heading-m">
-        Who manages this service
+        Who we are
       </h2>
       <p class="govuk-body">
-        The joint controllers for the Emergency Alerts service are the <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport">
-        Department for Digital, Culture, Media &amp; Sport</a> (DCMS) and the <a class="govuk-link" href="https://www.gov.uk/government/organisations/cabinet-office">Cabinet Office</a> COBR Unit.
+        GOV.UK Emergency Alerts is a service that lets public sector teams in the UK send alerts if there’s a danger to life.
       </p>
       <p class="govuk-body">
-        The Emergency Alerts service is provided by the <a class="govuk-link" href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a> (GDS) working with partners across central government, local government and mobile network operators.
+        GOV.UK Emergency Alerts is provided by the Government Digital Service (GDS) which is part of the Cabinet Office.
       </p>
       <p class="govuk-body">
-        The Cabinet Office is the data controller for any personal data processed on gov.uk/alerts and the feedback survey.
+        Organisations sending alerts using GOV.UK Emergency Alerts are the data controller and Cabinet Office is the data processor. The data controller must tell you what they’re doing with your personal data.
       </p>
       <p class="govuk-body">
-        A data controller decides how and why personal data is processed. For more information, read the Cabinet Office’s entry in the  <a class="govuk-link" href="https://ico.org.uk/ESDWebPages/Entry/Z7414053">Data Protection Public Register.</a>
+        For the credentials used to access GOV.UK Emergency Alerts, Cabinet Office is the data controller.
       </p>
-      <h2 class="govuk-heading-m" id="what-personal-data-we-collect">
-        What personal data we collect
+      <p class="govuk-body">
+        For more information see the Information Commissioner’s Office (ICO) <a class="govuk-link" href="https://ico.org.uk/esdwebpages/search">Data Protection Public Register</a>. The Cabinet Office registration number is: Z7414053.
+      </p>
+      <h2 class="govuk-heading-m" id="what-data-we-collect-from-you">
+        What data we collect from you
       </h2>
-      <h3 class="govuk-heading-s" id="emergency-alerts">
-        From the Emergency Alerts service
-      </h3>
       <p class="govuk-body">
-        Emergency alerts are broadcast from mobile phone masts to every compatible phone and tablet within range. The sender does not need to know your mobile phone number or any other personal data to send you an alert.
-      </p>
-      <p class="govuk-body">
-        No one will collect or share data about you, your phone or your location when you receive an emergency alert.
-      </p>
-      <h3 class="govuk-heading-s" id="gov-uk-alerts">
-        From gov.uk/alerts
-      </h3>
-      <p class="govuk-body">
-        When you visit gov.uk/alerts, we collect your Internet Protocol (IP) address, and details of which operating system and <a class="govuk-link" href="https://www.gov.uk/support/browsers">web browser</a> you used.
-      </p>
-      <p class="govuk-body">
-        We do not use cookies or page tagging to collect information about how you use the site.
-      </p>
-      <h3 class="govuk-heading-s" id="feedback-survey">
-        From user feedback
-      </h3>
-      <p class="govuk-body">
-        Emergency Alerts is a new UK government service and we'll be collecting anonymised user feedback to improve it.
-      </p>
-      <p class="govuk-body">
-        An anonymous survey and user feedback ask questions about your:
+        The personal data we collect from public sector employees that create a GOV.UK Emergency Alerts account includes:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>experience of receiving an emergency alert</li>
-        <li>opinion on the Emergency Alerts guidance</li>
+        <li>your name</li>
+        <li>your email address</li>
+        <li>your mobile phone number</li>
+        <li>the IP address you use to access GOV.UK Emergency Alerts</li>
       </ul>
       <p class="govuk-body">
-        The questions do not ask you for personal information. We will not process data that could be used to identify you, such as your name, address or phone number.
-      </p>
-      <h2 class="govuk-heading-m" id="our-legal-basis-for-processing-your-data">
-        Our legal basis for processing your data
-      </h2>
-      <p class="govuk-body">
-        As we’re not processing your personal data, the basis for sending emergency alerts is that they're in the public interest.
-      </p>
-      <p class="govuk-body">
-        However, the <a class="govuk-link" href="https://www.legislation.gov.uk/uksi/2003/2426/regulation/16A">
-        Privacy and Electronic Communications Regulations (PECR) 2003</a> also apply.
-      </p>
-      <p class="govuk-body">
-        The PECR says that some public authorities can ask mobile network operators to send an emergency alert if an emergency:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>has happened</li>
-        <li>is happening</li>
-        <li>is about to happen</li>
-      </ul>
-      <p class="govuk-body">
-        An ‘emergency’ is defined in <a class="govuk-link" href="https://www.legislation.gov.uk/ukpga/2004/36/part/1">part 1 of the Civil Contingencies Act 2004</a>. For more information, read <a class="govuk-link" href="/alerts/how-alerts-work">how emergency alerts work</a>.
+        The legal basis for processing this data is ‘public task’ – allowing you to access GOV.UK Emergency Alerts to send alerts to the public.
       </p>
       <h2 class="govuk-heading-m" id="why-we-need-your-data">
         Why we need your data
       </h2>
       <p class="govuk-body">
-        We do not require or need to process your personal data for Emergency Alerts.
+        We need your personal data to make sure only approved users of GOV.UK Emergency Alerts can use it to send alerts.
       </p>
       <h2 class="govuk-heading-m" id="what-we-do-with-your-data">
         What we do with your data
       </h2>
       <p class="govuk-body">
-        We may share anonymised data about visits to gov.uk/alerts with other government departments, agencies and public bodies.
-      </p>
-      <p class="govuk-body">
-        We may also share anonymised data with our technology suppliers, for example, our hosting provider and the mobile network operators.
+        We use your data to check that you are allowed to access GOV.UK Emergency Alerts and to record your activity when using it. We use third party suppliers to do this.
       </p>
       <p class="govuk-body">
         We will not:
@@ -138,139 +86,123 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>sell or rent your data to third parties</li>
         <li>share your data with third parties for marketing purposes</li>
-        <li>use your data in analytics</li>
       </ul>
       <p class="govuk-body">
-        We will share your data if we are required to do so by law – for example, by court order or to prevent fraud or other crime.
+        We will share your data if we are required to do so by law, for example, by court order, or to prevent fraud or other crime.
       </p>
       <h2 class="govuk-heading-m" id="how-long-we-keep-your-data">
         How long we keep your data
       </h2>
       <p class="govuk-body">
-        For the Emergency Alerts service and gov.uk/alerts webpages, there is no data processing undertaken and, therefore, no retention of data.
+        We’ll keep your personal data for as long as you have a GOV.UK  Emergency Alerts account.
       </p>
       <p class="govuk-body">
-        We will delete anonymised feedback survey data after 1 year.
+        When you ask us to close your account, we will delete your data within 1 year.
+      </p>
+      <p class="govuk-body">
+        When we close your account we’ll delete your:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>name</li>
+        <li>mobile phone number</li>
+        <li>GOV.UK Emergency Alerts password</li>
+      </ul>
+      <p class="govuk-body">
+        So we can carry out security audits, we’ll keep your email address and IP addresses for 1 year before we delete them.
+      </p>
+      <p class="govuk-body">
+        We will delete anonymised feedback data after 1 year.
+      </p>
+      <h2 class="govuk-heading-m" id="where-your-data-is-processed-and-stored">
+        Where your data is processed and stored
+      </h2>
+      <p class="govuk-body">
+        We design, build and run our systems to make sure that your data is safe at any stage, both while it’s processed and when it’s stored.
+      </p>
+      <p class="govuk-body">
+        Your personal data will only be processed in the UK and is safeguarded through <a class="govuk-link" href="https://ico.org.uk/for-organisations/dp-at-the-end-of-the-transition-period/data-protection-and-the-eu-in-detail/adequacy/">adequacy decisions</a>.
+      </p>
+      <h2 class="govuk-heading-m" id="how-we-protect-your-data-and-keep-it-secure">
+        How we protect your data and keep it secure
+      </h2>
+      <p class="govuk-body">
+        We are committed to doing all that we can to keep your data secure. To prevent unauthorised access or disclosure we have put in place technical and organisational procedures to secure the data we collect about you, for example, we protect your data using encryption. We also make sure any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.
       </p>
       <h2 class="govuk-heading-m" id="childrens-privacy-protection">
         Children’s privacy protection
       </h2>
       <p class="govuk-body">
-        Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. We will not be collecting or maintaining data about anyone.
+        We understand the importance of protecting children’s privacy online. Our services are not designed for, or intentionally targeted at, children 13 years of age or younger. It is not our policy to intentionally collect or maintain data about anyone under the age of 13.
       </p>
-      <h2 class="govuk-heading-m" id="where-your-data-is-processed">
-        Where your data is processed and stored
+      <h2 class="govuk-heading-m" id="what-are-your-rights">
+        What are your rights
       </h2>
       <p class="govuk-body">
-        No personal data is collected or stored for the Emergency Alerts service.
-      </p>
-      <h2 class="govuk-heading-m" id="how-we-protect-your-data">
-        How we protect your data and keep it secure
-      </h2>
-      <p class="govuk-body">
-        We are not collecting your data for the Emergency Alerts service
-      </p>
-      <h2 class="govuk-heading-m" id="your-rights">
-        Your rights
-      </h2>
-      <p class="govuk-body">
-        You can <a class="govuk-link" href="/alerts/how-alerts-work#opt-out">opt out</a> of emergency alerts at any time.
-      </p>
-      <p class="govuk-body">
-        Your personal data is not processed for this service.
-      </p>
-      <h2 class="govuk-heading-m" id="links-to-other-websites">
-        Links to other websites
-      </h2>
-      <p class="govuk-body">
-        This privacy notice only applies to the Emergency Alerts service, gov.uk/alerts webpages and user feedback.
-      </p>
-      <p class="govuk-body">
-        It does not cover:
+        You have the right to request:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>the rest of the GOV.UK domain</li>
-        <li>other government services and transactions</li>
-        <li>any other websites that we link to</li>
+        <li>information about how your personal data is processed</li>
+        <li>a copy of that personal data - this copy will be provided in a structured, commonly used and machine-readable format</li>
+        <li>that anything inaccurate in your personal data is corrected immediately</li>
       </ul>
       <p class="govuk-body">
-        Other government services have their own terms and conditions and privacy policies.
-      </p>
-      <p class="govuk-body">
-        If you go to another website from this one, read the privacy policy on that website to find out what it does with your information.
-      </p>
-      <h2 class="govuk-heading-m" id="contact-us">
-        Contact us or make a complaint
-      </h2>
-      <p class="govuk-body">
-        If you have a question or complaint, you can contact the Cabinet Office Privacy Team, Cabinet Office Data Protection Officer or the Information Commissioner.
-      </p>
-      <h2 class="govuk-heading-m" id="privacy-team">
-        Cabinet Office Privacy Team
-      </h2>
-      <p class="govuk-body">
-        Email the Cabinet Office Privacy Team if you:
+        You can also:
       </p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>have a question about anything in this privacy notice</li>
+        <li>raise an objection about how your personal data is processed</li>
+        <li>request that your personal data is deleted if there is no longer a justification for it</li>
+        <li>ask that the processing of your personal data is restricted in certain circumstances</li>
+      </ul>
+      <p class="govuk-body">
+        If you have any of these requests, contact the Cabinet Office Data Protection Officer.
+      </p>
+      <h2 class="govuk-heading-m" id="changes-to-this-notice">
+        Changes to this notice
+      </h2>
+      <p class="govuk-body">
+        We may modify or amend this privacy notice at our discretion at any time. When we make changes to this notice, we will amend the last modified date at the top of this page. Any modification or amendment to this privacy notice will be applied to you and your data as of that revision date. We encourage you to periodically review this privacy notice to be informed about how we are protecting your data.
+      </p>
+      <h2 class="govuk-heading-m" id="questions-and-complaints">
+        Questions and complaints
+      </h2>
+      <p class="govuk-body">
+        Contact the Cabinet Office Privacy Team if you either:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>have questions about anything in this privacy notice</li>
         <li>think that your personal data has been misused or mishandled</li>
       </ul>
-      <div class="address">
-        <p class="govuk-body">
-          CO Privacy Team<br>
-          <a class="govuk-link" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk" data-hsupport="email">subject.access@cabinetoffice.gov.uk</a>
-        </p>
-      </div>
-      <h2 class="govuk-heading-m" id="data-protection-officer">
-        Data Protection Officer (DPO)
-      </h2>
       <p class="govuk-body">
-        You can also write to or email the Cabinet Office Data Protection Officer.
-      </p>
-      <div class="address">
-        <p class="govuk-body">
-          Cabinet Office<br>
-          70 Whitehall<br>
-          London<br>
-          SW1A 2AS<br>
-          Email: <a class="govuk-link" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
-        </p>
-      </div>
-      <p class="govuk-body">
-        The DPO provides independent advice and monitoring of our use of personal information.
-      </p>
-      <h2 class="govuk-heading-m" id="information-officer">
-        Information Commissioner
-      </h2>
-      <p class="govuk-body">
-        You can also make a complaint to the Information Commissioner, who is an independent regulator.
-      </p>
-      <div class="address">
-        <p class="govuk-body">
-          Information Commissioner's Office<br>
-          Wycliffe House<br>
-          Water Lane<br>
-          Wilmslow<br>
-          Cheshire<br>
-          SK9 5AF<br>
-          Email: <a class="govuk-link" href="casework@ico.org.uk">casework@ico.org.uk</a><br>
-          Telephone: 0303 123 1113<br>
-          Textphone: 01625 545860<br>
-          Monday to Friday, 9am to 4:30pm<br>
-          <a class="govuk-link" href="https://www.gov.uk/call-charges">Find out about call charges</a><br>
-        </p>
-      </div>
-      <h2 class="govuk-heading-m" id="changes-to-this-policy">
-        Changes to this policy
-      </h2>
-      <p class="govuk-body">
-        We may change this privacy policy. In that case, the ‘last updated’ date at the bottom of this page will also change. Any changes to this privacy policy will apply to you and your data immediately.
+        Cabinet Office Privacy Team<br>
+        <a class="govuk-link" href="mailto:subject.access@cabinetoffice.gov.uk">subject.access@cabinetoffice.gov.uk</a>
       </p>
       <p class="govuk-body">
-        If these changes affect how your personal data is processed, GDS will take reasonable steps to let you know.
+        You can also contact the Cabinet Office Data Protection Officer.
       </p>
       <p class="govuk-body">
-        Last updated March 2023.
+        Cabinet Office<br>
+        70 Whitehall<br>
+        London<br>
+        SW1A 2AS<br>
+        Email: <a class="govuk-link" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a>
+      </p>
+      <p class="govuk-body">
+        If you have a complaint, you can also contact the <a class="govuk-link" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.
+      </p>
+      <p class="govuk-body">
+        Information Commissioner's Office<br>
+        Wycliffe House<br>
+        Water Lane<br>
+        Wilmslow<br>
+        Cheshire<br>
+        SK9 5AF
+      </p>
+      <p class="govuk-body">
+        Email: <a class="govuk-link" href="https://www.gov.uk/alerts/casework@ico.org.uk">casework@ico.org.uk</a><br>
+        Telephone: 0303 123 1113<br>
+        Textphone: 01625 545860<br>
+        Monday to Friday, 9am to 4:30pm<br>
+        <a class="govuk-link" href="https://www.gov.uk/call-charges">Find out about call charges</a>
       </p>
     </div>
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
EAS-914
- The content of the Privacy notice page (https://www.gov.uk/alerts/privacy-notice) has been updated to reflect the https://www.notifications.service.gov.uk/privacy page.

EAS-1081
- The content changes also include fixes to the 'mailto:' links on the email references in the body text.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
