### PR TITLE
EAS-1081 Revert previous deployment and fix mailto links

### DIFF
--- a/app/templates/views/privacy-notice.html
+++ b/app/templates/views/privacy-notice.html
@@ -218,7 +218,7 @@
       <div class="address">
         <p class="govuk-body">
           CO Privacy Team<br>
-          <a class="govuk-link" href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk" data-hsupport="email">subject.access@cabinetoffice.gov.uk</a>
+          <a class="govuk-link" href="mailto:subject.access@cabinetoffice.gov.uk" data-hsupport="email">subject.access@cabinetoffice.gov.uk</a>
         </p>
       </div>
       <h2 class="govuk-heading-m" id="data-protection-officer">
@@ -253,7 +253,7 @@
           Wilmslow<br>
           Cheshire<br>
           SK9 5AF<br>
-          Email: <a class="govuk-link" href="casework@ico.org.uk">casework@ico.org.uk</a><br>
+          Email: <a class="govuk-link" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
           Telephone: 0303 123 1113<br>
           Textphone: 01625 545860<br>
           Monday to Friday, 9am to 4:30pm<br>


### PR DESCRIPTION
The privacy page changes in the previous commit have been reverted and the incorrect mailto links fixed.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
