### PR TITLE
fix operator tests content first paragraph

### DIFF
--- a/app/templates/views/system-testing.html
+++ b/app/templates/views/system-testing.html
@@ -68,7 +68,7 @@
         </h2>
       {% endif %}
       <p class="govuk-body">
-        Following the successful national test of the UK Emergency Alerts system on 23 April 2023, the government and mobile network operators will be carrying out occasional ‘operator’ tests to assess improvements that have been made to the service.
+        Following the successful national test of the UK Emergency Alerts system on 23 April 2023, the government and mobile network operators will be carrying out occasional ‘operator’ tests.
       </p>
       <p class="govuk-body">
         This is to assess improvements that have been made to the Emergency Alerts service.

--- a/tests/app/main/views/test_system_testing.py
+++ b/tests/app/main/views/test_system_testing.py
@@ -13,7 +13,7 @@ def test_system_testing_page(mocker, client_get):
     assert html.select_one('h1').text.strip() == "Testing the Emergency Alerts service"
     assert html.select_one('main p').text.strip() == "Following the successful national test of the UK Emergency " \
         "Alerts system on 23 April 2023, the government and mobile network operators will be carrying out " \
-        "occasional ‘operator’ tests to assess improvements that have been made to the service."
+        "occasional ‘operator’ tests."
 
 
 @pytest.mark.parametrize('extra_json_fields', (


### PR DESCRIPTION
Remove " to assess improvements that have been made to the service." from the first paragraph of the system testing page to reflect content designs.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
