### PR TITLE
EAS-1173 Fix Related Content A11y

### DIFF
--- a/app/templates/components/related_content.html
+++ b/app/templates/components/related_content.html
@@ -1,13 +1,13 @@
 {% macro related_content(params) -%}
   <aside class="app-related-items" role="complementary">
-    <h2 class="govuk-heading-m" id="subsection-title">
+    <h2 class="govuk-heading-m" id="related-content">
     {% if params.language == 'cy' %}
       Cynnwys cysylltiedig
     {% else %}
       Related content
     {% endif %}
     </h2>
-    <nav role="navigation" aria-labelledby="subsection-title">
+    <nav role="navigation" aria-labelledby="related-content">
       <ul class="govuk-list govuk-!-font-size-16">
         {% for item in params['items'] %}
           <li>

--- a/app/templates/views/index.cy.html
+++ b/app/templates/views/index.cy.html
@@ -64,7 +64,7 @@
     {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m" id="subsection-title">
+    <h2 class="govuk-heading-m" id="alert-status">
       Does dim rhybuddion argyfwng ar hyn o bryd
     </h2>
   {% endif %}

--- a/app/templates/views/index.html
+++ b/app/templates/views/index.html
@@ -63,7 +63,7 @@
     {% endif %}
   {% else %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m" id="subsection-title">
+    <h2 class="govuk-heading-m" id="alert-status">
       There are no current alerts
     </h2>
   {% endif %}


### PR DESCRIPTION
Small change, just gives distinct ids to status box/related content so sections are clearer to screen reader users

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
