### PR TITLE
EAS-1576 Add config for local running

### DIFF
--- a/.github/pull_request_template.yml
+++ b/.github/pull_request_template.yml
@@ -1,8 +1,0 @@
-
-
-
----
-
-🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨
-
-See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Bootstrap Python app and run tests
         run: |
-          export ENVIRONMENT='development'
+          export ENVIRONMENT='local'
           set -eu
           make bootstrap
           make test

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ def create_app():
     )
 
     from app.config import configs
-    environment = os.getenv('HOST', 'development')
+    environment = os.getenv('HOST', 'local')
     application.config.from_object(configs[environment])
 
     from app.main import bp as main

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ def create_app():
     )
 
     from app.config import configs
-    environment = os.getenv('NOTIFY_ENVIRONMENT', 'development')
+    environment = os.getenv('HOST', 'development')
     application.config.from_object(configs[environment])
 
     from app.main import bp as main

--- a/app/config.py
+++ b/app/config.py
@@ -110,16 +110,16 @@ class Development(Config):
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-dev.yaml"
 
 
-# class Test(Config):
-#     DEBUG = True
+class Test(Config):
+    DEBUG = True
 
-#     FASTLY_SERVICE_ID = "test-service-id"
-#     FASTLY_API_KEY = "test-api-key"
-#     FASTLY_SURROGATE_KEY = "test-surrogate-key"
+    FASTLY_SERVICE_ID = "test-service-id"
+    FASTLY_API_KEY = "test-api-key"
+    FASTLY_SURROGATE_KEY = "test-surrogate-key"
 
-#     BROADCASTS_AWS_ACCESS_KEY_ID = "test-key-id"
-#     BROADCASTS_AWS_SECRET_ACCESS_KEY = "test-secret-key"
-#     GOVUK_ALERTS_S3_BUCKET_NAME = "test-bucket-name"
+    BROADCASTS_AWS_ACCESS_KEY_ID = "test-key-id"
+    BROADCASTS_AWS_SECRET_ACCESS_KEY = "test-secret-key"
+    GOVUK_ALERTS_S3_BUCKET_NAME = "test-bucket-name"
 
 
 # class Staging(Config):
@@ -133,7 +133,7 @@ class Development(Config):
 configs = {
     "development": Development,
     "hosted": Hosted,
-    # "test": Test,
+    "test": Test,
     # "staging": Staging,
     # "preview": Preview,
     # "production": Config,

--- a/app/config.py
+++ b/app/config.py
@@ -49,7 +49,7 @@ class Config():
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests.yaml"
 
 
-class Decoupled(Config):
+class Hosted(Config):
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
     SQS_QUEUE_BASE_URL = os.getenv("SQS_QUEUE_BASE_URL")
@@ -110,31 +110,31 @@ class Development(Config):
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-dev.yaml"
 
 
-class Test(Config):
-    DEBUG = True
+# class Test(Config):
+#     DEBUG = True
 
-    FASTLY_SERVICE_ID = "test-service-id"
-    FASTLY_API_KEY = "test-api-key"
-    FASTLY_SURROGATE_KEY = "test-surrogate-key"
+#     FASTLY_SERVICE_ID = "test-service-id"
+#     FASTLY_API_KEY = "test-api-key"
+#     FASTLY_SURROGATE_KEY = "test-surrogate-key"
 
-    BROADCASTS_AWS_ACCESS_KEY_ID = "test-key-id"
-    BROADCASTS_AWS_SECRET_ACCESS_KEY = "test-secret-key"
-    GOVUK_ALERTS_S3_BUCKET_NAME = "test-bucket-name"
-
-
-class Staging(Config):
-    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-staging.yaml"
+#     BROADCASTS_AWS_ACCESS_KEY_ID = "test-key-id"
+#     BROADCASTS_AWS_SECRET_ACCESS_KEY = "test-secret-key"
+#     GOVUK_ALERTS_S3_BUCKET_NAME = "test-bucket-name"
 
 
-class Preview(Config):
-    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-preview.yaml"
+# class Staging(Config):
+#     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-staging.yaml"
+
+
+# class Preview(Config):
+#     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-preview.yaml"
 
 
 configs = {
     "development": Development,
-    "decoupled": Decoupled,
-    "test": Test,
-    "staging": Staging,
-    "preview": Preview,
-    "production": Config,
+    "hosted": Hosted,
+    # "test": Test,
+    # "staging": Staging,
+    # "preview": Preview,
+    # "production": Config,
 }

--- a/app/config.py
+++ b/app/config.py
@@ -49,13 +49,6 @@ class Config():
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests.yaml"
 
 
-class Development(Config):
-    NOTIFY_API_CLIENT_SECRET = "govuk-alerts-secret-key"
-    NOTIFY_API_HOST_NAME = "http://localhost:6011"
-
-    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-dev.yaml"
-
-
 class Hosted(Config):
     # Prefix to identify queues in SQS
     NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
@@ -122,20 +115,8 @@ class Test(Config):
     GOVUK_ALERTS_S3_BUCKET_NAME = "test-bucket-name"
 
 
-# class Staging(Config):
-#     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-staging.yaml"
-
-
-# class Preview(Config):
-#     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-preview.yaml"
-
-
 configs = {
     "local": Config,
-    "development": Development,
     "hosted": Hosted,
     "test": Test,
-    # "staging": Staging,
-    # "preview": Preview,
-    # "production": Config,
 }

--- a/app/config.py
+++ b/app/config.py
@@ -19,8 +19,8 @@ class Config():
     FASTLY_API_KEY = os.getenv("FASTLY_API_KEY")
     FASTLY_SURROGATE_KEY = "notify-emergency-alerts"
 
-    NOTIFY_API_HOST_NAME = os.environ.get("NOTIFY_API_HOST_NAME")
-    NOTIFY_API_CLIENT_SECRET = os.environ.get("NOTIFY_API_CLIENT_SECRET")
+    NOTIFY_API_HOST_NAME = "http://localhost:6011"
+    NOTIFY_API_CLIENT_SECRET = "govuk-alerts-secret-key"
     NOTIFY_API_CLIENT_ID = "govuk-alerts"
 
     CELERY = {
@@ -47,6 +47,13 @@ class Config():
     STATSD_ENABLED = bool(STATSD_HOST)
 
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests.yaml"
+
+
+class Development(Config):
+    NOTIFY_API_CLIENT_SECRET = "govuk-alerts-secret-key"
+    NOTIFY_API_HOST_NAME = "http://localhost:6011"
+
+    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-dev.yaml"
 
 
 class Hosted(Config):
@@ -103,13 +110,6 @@ class Hosted(Config):
     PLANNED_TESTS_YAML_FILE_NAME = "planned-tests.yaml"
 
 
-class Development(Config):
-    NOTIFY_API_CLIENT_SECRET = "govuk-alerts-secret-key"
-    NOTIFY_API_HOST_NAME = "http://localhost:6011"
-
-    PLANNED_TESTS_YAML_FILE_NAME = "planned-tests-dev.yaml"
-
-
 class Test(Config):
     DEBUG = True
 
@@ -131,6 +131,7 @@ class Test(Config):
 
 
 configs = {
+    "local": Config,
     "development": Development,
     "hosted": Hosted,
     "test": Test,

--- a/app/models/planned_tests.py
+++ b/app/models/planned_tests.py
@@ -12,7 +12,7 @@ from app.utils import REPO
 class PlannedTests(SerialisedModelCollection):
     model = PlannedTest
     planned_tests = defaultdict()
-    environment = os.getenv('HOST', 'development')
+    environment = os.getenv('HOST', 'local')
     yaml_filename = (configs[environment].PLANNED_TESTS_YAML_FILE_NAME)
 
     @classmethod

--- a/app/models/planned_tests.py
+++ b/app/models/planned_tests.py
@@ -12,7 +12,7 @@ from app.utils import REPO
 class PlannedTests(SerialisedModelCollection):
     model = PlannedTest
     planned_tests = defaultdict()
-    environment = os.getenv('NOTIFY_ENVIRONMENT', 'development')
+    environment = os.getenv('HOST', 'development')
     yaml_filename = (configs[environment].PLANNED_TESTS_YAML_FILE_NAME)
 
     @classmethod

--- a/app/utils.py
+++ b/app/utils.py
@@ -50,7 +50,7 @@ def is_in_uk(simple_polygons):
 
 
 def upload_html_to_s3(rendered_pages):
-    notify_environment = os.environ.get('NOTIFY_ENVIRONMENT')
+    notify_environment = os.environ.get('HOST')
 
     if (notify_environment == "decoupled"):
         session = boto3.Session()
@@ -80,7 +80,7 @@ def upload_assets_to_s3():
     if not Path(DIST).exists():
         raise FileExistsError(f'Folder {DIST} not found.')
 
-    notify_environment = os.environ.get('NOTIFY_ENVIRONMENT')
+    notify_environment = os.environ.get('HOST')
 
     if (notify_environment == "decoupled"):
         session = boto3.Session()

--- a/app/utils.py
+++ b/app/utils.py
@@ -52,7 +52,7 @@ def is_in_uk(simple_polygons):
 def upload_html_to_s3(rendered_pages):
     notify_environment = os.environ.get('HOST')
 
-    if (notify_environment == "decoupled"):
+    if (notify_environment == "hosted"):
         session = boto3.Session()
 
     else:
@@ -82,7 +82,7 @@ def upload_assets_to_s3():
 
     notify_environment = os.environ.get('HOST')
 
-    if (notify_environment == "decoupled"):
+    if (notify_environment == "hosted"):
         session = boto3.Session()
 
     else:

--- a/app/utils.py
+++ b/app/utils.py
@@ -50,9 +50,9 @@ def is_in_uk(simple_polygons):
 
 
 def upload_html_to_s3(rendered_pages):
-    notify_environment = os.environ.get('HOST')
+    host_environment = os.environ.get('HOST')
 
-    if (notify_environment == "hosted"):
+    if (host_environment == "hosted"):
         session = boto3.Session()
 
     else:
@@ -80,9 +80,9 @@ def upload_assets_to_s3():
     if not Path(DIST).exists():
         raise FileExistsError(f'Folder {DIST} not found.')
 
-    notify_environment = os.environ.get('HOST')
+    host_environment = os.environ.get('HOST')
 
-    if (notify_environment == "hosted"):
+    if (host_environment == "hosted"):
         session = boto3.Session()
 
     else:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -29,7 +29,7 @@ applications:
     env:
       # Logging and metrics
       LOGGING_STDOUT_JSON: '1'
-      NOTIFY_ENVIRONMENT: '{{ environment }}'
+      HOST: '{{ environment }}'
       NOTIFY_LOG_PATH: '/home/vcap/logs/app.log'
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 testpaths = tests
 env =
-    NOTIFY_ENVIRONMENT=test
+    HOST=test
 xfail_strict = True
 # suppress deprecation warnings from within dependencies (celery, flask and flask respeectively)
 filterwarnings =


### PR DESCRIPTION
The HOST variable is used to distinguish between running locally and on the hosted infrastructure (i.e. AWS). This variable can therefore take one of the following values:

HOST = [ local | hosted | test ]

"local" indicates that the service will be configured for running on a local machine. "hosted" is intended for use when the service is running on the AWS-hosted infrastructure. "test" provides a special set of configuration values that are used by the unit, integration and functional tests.

The environment variable ENVIRONMENT is used to tell the service which set of config values to take up, and can be set to one of the following values:

ENVIRONMENT = [ local | development | preview | staging | production ]

A value of "local" indicates that the service will be running on the development machine. A value corresponding to any of the others in the above set maps directly to the name of the environment hosted in AWS.

The development environment hosted on AWS will now configure the above variables as follows:
HOST=hosted & ENVIRONMENT=development

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

See [docs/deploying.md](docs/deploying.md) for notes and caveats about this app.
