### PR TITLE
EAS 1736 Multi Tenant Dev - tenant prefixing

### DIFF
--- a/.codepipeline/buildspec-govuk-build.yml
+++ b/.codepipeline/buildspec-govuk-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER --no-cache .
+        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=$ECR_RESOURCE_PREFIX --no-cache .
   post_build:
     commands:
       - echo Building complete on `date`

--- a/.codepipeline/buildspec-govuk-build.yml
+++ b/.codepipeline/buildspec-govuk-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${ECR_RESOURCE_PREFIX:-eas-app} --no-cache .
+        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache .
   post_build:
     commands:
       - echo Building complete on `date`

--- a/.codepipeline/buildspec-govuk-build.yml
+++ b/.codepipeline/buildspec-govuk-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=$ECR_RESOURCE_PREFIX --no-cache .
+        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${ECR_RESOURCE_PREFIX:-eas-app} --no-cache .
   post_build:
     commands:
       - echo Building complete on `date`

--- a/.codepipeline/buildspec-govuk-build.yml
+++ b/.codepipeline/buildspec-govuk-build.yml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building Docker image...
       - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:pipeline_$EXECUTION_ID -t $REPOSITORY_URI:commit_$COMMIT_ID
-        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache .
+        -f Dockerfile.eas-govuk-alerts --build-arg ECS_ACCOUNT_NUMBER=$ACCOUNT_NUMBER --build-arg RESOURCE_PREFIX=${RESOURCE_PREFIX:-eas-app} --no-cache .
   post_build:
     commands:
       - echo Building complete on `date`

--- a/.codepipeline/buildspec-govuk-deploy.yml
+++ b/.codepipeline/buildspec-govuk-deploy.yml
@@ -8,4 +8,4 @@ phases:
   build:
     commands:
       - echo Deployment started on `date`
-      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts
+      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX $ECR_RESOURCE_PREFIX

--- a/.codepipeline/buildspec-govuk-deploy.yml
+++ b/.codepipeline/buildspec-govuk-deploy.yml
@@ -8,4 +8,4 @@ phases:
   build:
     commands:
       - echo Deployment started on `date`
-      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX ${ECR_RESOURCE_PREFIX:-eas-app}
+      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX ${RESOURCE_PREFIX:-eas-app}

--- a/.codepipeline/buildspec-govuk-deploy.yml
+++ b/.codepipeline/buildspec-govuk-deploy.yml
@@ -8,4 +8,4 @@ phases:
   build:
     commands:
       - echo Deployment started on `date`
-      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX $ECR_RESOURCE_PREFIX
+      - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX ${ECR_RESOURCE_PREFIX:-eas-app}

--- a/.codepipeline/deploy-service.sh
+++ b/.codepipeline/deploy-service.sh
@@ -1,5 +1,4 @@
 #! /bin/sh
-CLUSTER_NAME=eas-app-cluster
 
 while [ $# -gt 0 ]; do
     if [[ $1 == *"--"* ]]; then
@@ -9,21 +8,23 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-function update_task_defintion(){
+CLUSTER_NAME=${RESOURCE_PREFIX}-cluster
+
+update_task_definition(){
     if [ -z "$SERVICE" ]; then
         echo "SERVICE is required."
         exit
     fi;
-    
+
     echo "=============== GETTING LATEST TASK DEFINITION ==============="
     latest_task_def=$(aws ecs list-task-definitions \
         --status ACTIVE \
         --sort DESC \
         --max-items 1 \
-        --family-prefix eas-app-$SERVICE \
+        --family-prefix ${RESOURCE_PREFIX}-${SERVICE} \
         --output json \
     | jq '.taskDefinitionArns[0]' | tr -d '"')
-    
+
     if [ -z "$latest_task_def" ]; then
         echo "Unable to retrieve the latest task definition."
         exit
@@ -33,10 +34,10 @@ function update_task_defintion(){
         echo "=============== UPDATING SERVICE ==============="
         aws ecs update-service \
         --cluster $CLUSTER_NAME \
-        --service eas-app-$SERVICE \
+        --service ${RESOURCE_PREFIX}-${SERVICE} \
         --task-definition $latest_task_def \
         --force-new-deployment
     fi
 }
 
-update_task_defintion
+update_task_definition

--- a/.codepipeline/deploy-service.sh
+++ b/.codepipeline/deploy-service.sh
@@ -8,7 +8,9 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-CLUSTER_NAME=${RESOURCE_PREFIX}-cluster
+PREFIX="${RESOURCE_PREFIX:-eas-app}"
+CLUSTER_NAME="${PREFIX}-cluster"
+echo "Using ${PREFIX} resources"
 
 update_task_definition(){
     if [ -z "$SERVICE" ]; then
@@ -21,7 +23,7 @@ update_task_definition(){
         --status ACTIVE \
         --sort DESC \
         --max-items 1 \
-        --family-prefix "${RESOURCE_PREFIX}-${SERVICE}" \
+        --family-prefix "${PREFIX}-${SERVICE}" \
         --output json \
     | jq '.taskDefinitionArns[0]' | tr -d '"')
 
@@ -34,7 +36,7 @@ update_task_definition(){
         echo "=============== UPDATING SERVICE ==============="
         aws ecs update-service \
         --cluster "$CLUSTER_NAME" \
-        --service "${RESOURCE_PREFIX}-${SERVICE}" \
+        --service "${PREFIX}-${SERVICE}" \
         --task-definition "$latest_task_def" \
         --force-new-deployment
     fi

--- a/.codepipeline/deploy-service.sh
+++ b/.codepipeline/deploy-service.sh
@@ -21,7 +21,7 @@ update_task_definition(){
         --status ACTIVE \
         --sort DESC \
         --max-items 1 \
-        --family-prefix ${RESOURCE_PREFIX}-${SERVICE} \
+        --family-prefix "${RESOURCE_PREFIX}-${SERVICE}" \
         --output json \
     | jq '.taskDefinitionArns[0]' | tr -d '"')
 
@@ -33,9 +33,9 @@ update_task_definition(){
         echo ""
         echo "=============== UPDATING SERVICE ==============="
         aws ecs update-service \
-        --cluster $CLUSTER_NAME \
-        --service ${RESOURCE_PREFIX}-${SERVICE} \
-        --task-definition $latest_task_def \
+        --cluster "$CLUSTER_NAME" \
+        --service "${RESOURCE_PREFIX}-${SERVICE}" \
+        --task-definition "$latest_task_def" \
         --force-new-deployment
     fi
 }

--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -1,5 +1,6 @@
 ARG ECS_ACCOUNT_NUMBER
-FROM ${ECS_ACCOUNT_NUMBER}.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
+ARG RESOURCE_PREFIX=eas-app
+FROM ${ECS_ACCOUNT_NUMBER}.dkr.ecr.eu-west-2.amazonaws.com/${RESOURCE_PREFIX}-base:latest
 
 ENV SERVICE=govuk-alerts
 ENV FLASK_APP=app.py

--- a/app/config.py
+++ b/app/config.py
@@ -53,7 +53,8 @@ class Hosted(Config):
     # Prefix to identify queues in SQS
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     TENANT_PREFIX = f"{os.environ.get('TENANT')}-" if os.environ.get("TENANT") is not None else ""
-    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-{TENANT_PREFIX}"
+    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT') if os.getenv('ENVIRONMENT') != 'development' else 'dev'} \
+        -{TENANT_PREFIX}"
     SQS_QUEUE_BASE_URL = os.getenv("SQS_QUEUE_BASE_URL")
     QUEUE_NAME = "govuk-alerts"
     SQS_QUEUE_BACKOFF_POLICY = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32, 7: 64, 8: 128}

--- a/app/config.py
+++ b/app/config.py
@@ -53,8 +53,8 @@ class Hosted(Config):
     # Prefix to identify queues in SQS
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     TENANT_PREFIX = f"{os.environ.get('TENANT')}-" if os.environ.get("TENANT") is not None else ""
-    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT') if os.getenv('ENVIRONMENT') != 'development' else 'dev'} \
-        -{TENANT_PREFIX}"
+    ENVIRONMENT_PREFIX = os.getenv('ENVIRONMENT') if os.getenv('ENVIRONMENT') != 'development' else 'dev'
+    NOTIFICATION_QUEUE_PREFIX = f"{ENVIRONMENT_PREFIX}-{TENANT_PREFIX}"
     SQS_QUEUE_BASE_URL = os.getenv("SQS_QUEUE_BASE_URL")
     QUEUE_NAME = "govuk-alerts"
     SQS_QUEUE_BACKOFF_POLICY = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32, 7: 64, 8: 128}

--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,7 @@ class Config():
 
 class Hosted(Config):
     # Prefix to identify queues in SQS
+    TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
     NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
     SQS_QUEUE_BASE_URL = os.getenv("SQS_QUEUE_BASE_URL")
     QUEUE_NAME = "govuk-alerts"
@@ -68,7 +69,7 @@ class Hosted(Config):
     FASTLY_API_KEY = os.getenv("FASTLY_API_KEY")
     FASTLY_SURROGATE_KEY = "notify-emergency-alerts"
 
-    NOTIFY_API_HOST_NAME = "http://api.ecs.local:6011"
+    NOTIFY_API_HOST_NAME = f"http://api.{TENANT}ecs.local:6011"
     NOTIFY_API_CLIENT_SECRET = os.environ.get("NOTIFY_API_CLIENT_SECRET")
     NOTIFY_API_CLIENT_ID = "govuk-alerts"
 

--- a/app/config.py
+++ b/app/config.py
@@ -52,7 +52,8 @@ class Config():
 class Hosted(Config):
     # Prefix to identify queues in SQS
     TENANT = f"{os.environ.get('TENANT')}." if os.environ.get("TENANT") is not None else ""
-    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-"
+    TENANT_PREFIX = f"{os.environ.get('TENANT')}-" if os.environ.get("TENANT") is not None else ""
+    NOTIFICATION_QUEUE_PREFIX = f"{os.getenv('ENVIRONMENT')}-{TENANT_PREFIX}"
     SQS_QUEUE_BASE_URL = os.getenv("SQS_QUEUE_BASE_URL")
     QUEUE_NAME = "govuk-alerts"
     SQS_QUEUE_BACKOFF_POLICY = {1: 1, 2: 2, 3: 4, 4: 8, 5: 16, 6: 32, 7: 64, 8: 128}

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -29,6 +29,7 @@ if [[ ! -z $DEBUG ]]; then
     done
 else
     configure_container_role
+    update_timestamp
     flask_publish
     run_celery
 fi

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -18,6 +18,7 @@ function flask_publish(){
 
 function update_timestamp(){
     echo $(date +%s) > $timestamp_filename
+    chown easuser:easuser $timestamp_filename
 }
 
 if [[ ! -z $DEBUG ]]; then


### PR DESCRIPTION
This PR amends the Dockerfiles and buildspec.yml files to enable dynamic resource prefixes when referring to (primarily) the appropriate ECR repository to use for the base image. This way, modifications can be made to the utils package and deployed to the particular user's development environment, and it will be referenced appropriately when building other application components (e.g., Admin, API) using it.