### PR TITLE
Implementation of capitalize util and usage for alerts

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -8,7 +8,7 @@ from jinja2 import (
     contextfilter,
 )
 
-from app.utils import DIST, REPO, file_fingerprint, paragraphize
+from app.utils import DIST, REPO, capitalise, file_fingerprint, paragraphize
 
 TEMPLATES = REPO / 'app' / 'templates'
 VIEWS = TEMPLATES / 'views'
@@ -67,6 +67,7 @@ def setup_jinja_environment(alerts):
     env.filters['file_fingerprint'] = file_fingerprint
     env.filters['formatted_list'] = formatted_list
     env.filters['paragraphize'] = paragraphize
+    env.filters['capitalise'] = capitalise
     env.filters['get_url_for_alert'] = jinja_filter_get_url_for_alert
     env.globals = {
         'font_paths': [

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -11,7 +11,7 @@
           </h{{ heading_level }}>
         {% else %}
           <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') }}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | capitalise }}
           </h{{ heading_level }}>
         {% endif %}
         {{ alert_body(alert) }}

--- a/app/utils.py
+++ b/app/utils.py
@@ -11,6 +11,10 @@ REPO = Path(__file__).parent.parent
 DIST = REPO / 'dist'
 
 
+def capitalise(value):
+    return value[0].upper() + value[1:]
+
+
 def paragraphize(value, classes="govuk-body-l govuk-!-margin-bottom-4"):
     paragraphs = [
         f'<p class="{classes}">{line}</p>'

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -21,5 +21,5 @@ def test_current_alerts_page_shows_alerts(
     link = html.select_one('a.govuk-body')
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == 'Emergency alert sent to foo'
+    assert titles[0].text.strip() == 'Emergency alert sent to Foo'
     assert 'More information about this alert' in link.text

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -17,7 +17,7 @@ def test_past_alerts_page(client_get):
 @pytest.mark.parametrize('is_public,expected_title,expected_link_text', [
     [
         True,
-        'Emergency alert sent to foo',
+        'Emergency alert sent to Foo',
         'More information about this alert',
     ]
 ])

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -8,6 +8,7 @@ from jinja2 import Markup
 from moto import mock_s3
 
 from app.utils import (
+    capitalise,
     file_fingerprint,
     is_in_uk,
     paragraphize,
@@ -24,6 +25,12 @@ def test_file_fingerprint_gets_variant_of_path_with_hash_in():
 def test_file_fingerprint_raises_for_file_not_found():
     with pytest.raises(OSError):
         file_fingerprint('/tests/test_files/doesnt-exist.txt', root=Path('.'))
+
+
+def test_capitalise_capitalises_first_letter():
+    text = "this is SoMe TeXt"
+    expected = 'This is SoMe TeXt'
+    assert capitalise(text) == expected
 
 
 def test_paragraphize_converts_newlines_to_paragraphs():


### PR DESCRIPTION
Simple implementation of a capitalisation util to ensure any alerts displayed have the first character of their display name capitalised (sometimes they will not be when retrieved from the database, for instance when using custom polygons).