### PR TITLE
EAS-2028 Apply version upgrades

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -5,7 +5,7 @@ from jinja2 import (
     FileSystemLoader,
     PackageLoader,
     PrefixLoader,
-    contextfilter,
+    pass_context,
 )
 
 from app.utils import DIST, REPO, file_fingerprint, paragraphize
@@ -18,7 +18,7 @@ all_view_paths = [
 ]
 
 
-@contextfilter
+@pass_context
 def jinja_filter_get_url_for_alert(jinja_context, alert):
     alerts = jinja_context['alerts']
     return get_url_for_alert(alert, alerts)

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import boto3
 import requests
 from flask import current_app
-from jinja2 import Markup, escape
+from markupsafe import Markup, escape
 
 REPO = Path(__file__).parent.parent
 DIST = REPO / 'dist'

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 govuk-frontend-jinja==2.8.0
-Jinja2==2.11.3
-MarkupSafe==1.1.1
+Jinja2==3.1.3
+MarkupSafe==2.1.5
 PyYAML==6.0.1
 boto3==1.20.26
 celery==5.2.7
-Flask==1.1.2
+Flask==3.0.2
 pycurl==7.43.0.6
 notifications-python-client==8.0.0
 
@@ -16,4 +16,4 @@ pytest==8.0.2
 pytest-mock==3.12.0
 beautifulsoup4==4.9.3
 pytest-env==1.1.3
-moto==2.2.3
+moto==5.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ beautifulsoup4==4.9.3
     # via -r requirements.in
 billiard==3.6.4.0
     # via celery
+blinker==1.7.0
+    # via flask
 boto3==1.20.26
     # via
     #   -r requirements.in
@@ -48,7 +50,7 @@ exceptiongroup==1.2.0
     # via pytest
 flake8==7.0.0
     # via -r requirements.in
-flask==1.1.2
+flask==3.0.2
     # via -r requirements.in
 freezegun==1.4.0
     # via -r requirements.in
@@ -57,14 +59,14 @@ govuk-frontend-jinja==2.8.0
 idna==3.3
     # via requests
 importlib-metadata==7.0.1
-    # via moto
+    # via flask
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via -r requirements.in
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via flask
-jinja2==2.11.3
+jinja2==3.1.3
     # via
     #   -r requirements.in
     #   flask
@@ -76,16 +78,14 @@ jmespath==0.10.0
     #   botocore
 kombu==5.2.3
     # via celery
-markupsafe==1.1.1
+markupsafe==2.1.5
     # via
     #   -r requirements.in
     #   jinja2
-    #   moto
+    #   werkzeug
 mccabe==0.7.0
     # via flake8
-more-itertools==10.2.0
-    # via moto
-moto==2.2.3
+moto==5.0.4
     # via -r requirements.in
 notifications-python-client==8.0.0
     # via -r requirements.in
@@ -122,9 +122,7 @@ python-dateutil==2.8.2
     #   freezegun
     #   moto
 pytz==2021.3
-    # via
-    #   celery
-    #   moto
+    # via celery
 pyyaml==6.0.1
     # via
     #   -r requirements.in
@@ -162,7 +160,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.0.2
+werkzeug==3.0.2
     # via
     #   flask
     #   moto

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-from jinja2 import Markup
-from moto import mock_s3
+from markupsafe import Markup
+from moto import mock_aws
 
 from app.utils import (
     file_fingerprint,
@@ -45,7 +45,7 @@ def test_is_in_uk_returns_polygons_in_uk_bounding_box(alert_dict, lat, lon, in_u
     assert is_in_uk(simple_polygons) == in_uk
 
 
-@mock_s3
+@mock_aws
 def test_upload_to_s3(govuk_alerts):
     client = boto3.client('s3')
     client.create_bucket(Bucket='test-bucket', CreateBucketConfiguration={'LocationConstraint': 'eu-west-2'})


### PR DESCRIPTION
Upgrade Flask, Jinja2 and other packages to pull in the latest version of Werkzeug (required to be upgraded to latest version https://github.com/alphagov/emergency-alerts-api/security/dependabot/2)