### PR TITLE
EAS-2030 Simplification of Custom Area names displayed

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -8,7 +8,14 @@ from jinja2 import (
     pass_context,
 )
 
-from app.utils import DIST, REPO, capitalise, file_fingerprint, paragraphize
+from app.utils import (
+    DIST,
+    REPO,
+    capitalise,
+    file_fingerprint,
+    paragraphize,
+    simplify_custom_area_name,
+)
 
 TEMPLATES = REPO / 'app' / 'templates'
 VIEWS = TEMPLATES / 'views'
@@ -69,6 +76,7 @@ def setup_jinja_environment(alerts):
     env.filters['paragraphize'] = paragraphize
     env.filters['capitalise'] = capitalise
     env.filters['get_url_for_alert'] = jinja_filter_get_url_for_alert
+    env.filters['simplify_custom_area_name'] = simplify_custom_area_name
     env.globals = {
         'font_paths': [
             item.relative_to(DIST)

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -11,7 +11,7 @@
           </h{{ heading_level }}>
         {% else %}
           <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | capitalise | simplify_custom_area_name}}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name |capitalise }}
           </h{{ heading_level }}>
         {% endif %}
         {{ alert_body(alert) }}

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -11,7 +11,7 @@
           </h{{ heading_level }}>
         {% else %}
           <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | capitalise }}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | capitalise | simplify_custom_area_name}}
           </h{{ heading_level }}>
         {% endif %}
         {{ alert_body(alert) }}

--- a/app/templates/components/alert.html
+++ b/app/templates/components/alert.html
@@ -11,7 +11,7 @@
           </h{{ heading_level }}>
         {% else %}
           <h{{ heading_level }} class="alerts-alert__title govuk-heading-s govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name |capitalise }}
+            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('en') |capitalise }}
           </h{{ heading_level }}>
         {% endif %}
         {{ alert_body(alert) }}
@@ -19,24 +19,24 @@
           {% if language == 'cy' %}
             <a href="/alerts/{{ alert | get_url_for_alert }}.cy" class="govuk-link govuk-body">
               Rhagor o wybodaeth am y rhybudd hwn
-              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') }}</span>
+              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('cy') }}</span>
             </a>
           {% else %}
             <a href="/alerts/{{ alert | get_url_for_alert }}" class="govuk-link govuk-body">
               More information about this alert
-              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') }}</span>
+              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('en') }}</span>
             </a>
           {% endif %}
         {% else %}
           {% if language == 'cy' %}
             <a href="/alerts/system-testing.cy" class="govuk-link govuk-body">
               Dysgwch ragor am profi'r gwasanaeth Rhybuddion Argyfwng
-              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') }}</span>
+              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('cy')}}</span>
             </a>
           {% else %}
             <a href="/alerts/system-testing" class="govuk-link govuk-body">
               Find out more about testing the Emergency Alerts service
-              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') }}</span>
+              <span class="govuk-visually-hidden">to {{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('en') }}</span>
             </a>
           {% endif %}
         {% endif %}

--- a/app/templates/views/alert.cy.html
+++ b/app/templates/views/alert.cy.html
@@ -9,7 +9,7 @@
 {%- from "components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "Emergency alert" %}
-{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') %}
+{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('cy') %}
 
 {% block metaTags %}
   {{ metaTags(

--- a/app/templates/views/alert.html
+++ b/app/templates/views/alert.html
@@ -9,7 +9,7 @@
 {%- from "components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "Emergency alert" %}
-{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') %}
+{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name %}
 
 {% block metaTags %}
   {{ metaTags(

--- a/app/templates/views/alert.html
+++ b/app/templates/views/alert.html
@@ -9,7 +9,7 @@
 {%- from "components/meta_tags.html" import metaTags -%}
 
 {% set pageTitle = "Emergency alert" %}
-{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name %}
+{% set alertAreaNames = alert_data.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('en') %}
 
 {% block metaTags %}
   {{ metaTags(

--- a/app/utils.py
+++ b/app/utils.py
@@ -16,13 +16,15 @@ def capitalise(value):
 
 
 def simplify_custom_area_name(value):
+    # Checking for words indicating that it is a
+    # custom area OR that is has a local authority in the name
     if (
         'postcode' not in value
         and 'easting' not in value
         and 'latitude' not in value
-    ):
+    ) or (" in " not in value):
         return value
-    local_authority = value.split(", in ")[1]
+    local_authority = value.split(" in ")[1]
     return f"an area in {local_authority}"
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -15,6 +15,17 @@ def capitalise(value):
     return value[0].upper() + value[1:]
 
 
+def simplify_custom_area_name(value):
+    if (
+        'postcode' not in value
+        and 'easting' not in value
+        and 'latitude' not in value
+    ):
+        return value
+    local_authority = value.split(", in ")[1]
+    return f"an area in {local_authority}"
+
+
 def paragraphize(value, classes="govuk-body-l govuk-!-margin-bottom-4"):
     paragraphs = [
         f'<p class="{classes}">{line}</p>'

--- a/app/utils.py
+++ b/app/utils.py
@@ -15,17 +15,29 @@ def capitalise(value):
     return value[0].upper() + value[1:]
 
 
-def simplify_custom_area_name(value):
-    # Checking for words indicating that it is a
-    # custom area OR that is has a local authority in the name
-    if (
-        'postcode' not in value
-        and 'easting' not in value
-        and 'latitude' not in value
-    ) or (" in " not in value):
+def simplify_custom_area_name(value, language):
+    if not is_custom_area_with_local_authority(value):
         return value
-    local_authority = value.split(" in ")[1]
-    return f"an area in {local_authority}"
+    local_authority = get_local_authority_from_custom_area(value)
+    if language == 'cy':
+        return f"ardal yn {local_authority}"
+    elif language == 'en':
+        return f"an area in {local_authority}"
+
+
+def get_local_authority_from_custom_area(value):
+    if is_custom_area_with_local_authority(value):
+        return value.split(" in ")[1]
+
+
+def is_custom_area_with_local_authority(value):
+    return (
+        (
+            'postcode' in value
+            or 'easting' in value
+            or 'latitude' in value
+        ) and (" in " in value)
+    )
 
 
 def paragraphize(value, classes="govuk-body-l govuk-!-margin-bottom-4"):

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -44,7 +44,7 @@ def test_current_alerts_page_shows_postcode_area_alerts(
     link = html.select_one("a.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to an area in Bradford"
+    assert titles[0].text.strip() == "Emergency alert sent to An area in Bradford"
     assert "More information about this alert" in link.text
 
 
@@ -67,7 +67,7 @@ def test_current_alerts_page_shows_decimal_coordinate_area_alerts(
     link = html.select_one("a.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to an area in Craven"
+    assert titles[0].text.strip() == "Emergency alert sent to An area in Craven"
     assert "More information about this alert" in link.text
 
 
@@ -90,5 +90,5 @@ def test_current_alerts_page_shows_cartesian_coordinate_area_alerts(
     link = html.select_one("a.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to an area in Lambeth"
+    assert titles[0].text.strip() == "Emergency alert sent to An area in Lambeth"
     assert "More information about this alert" in link.text

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -23,3 +23,72 @@ def test_current_alerts_page_shows_alerts(
     assert len(titles) == 1
     assert titles[0].text.strip() == 'Emergency alert sent to Foo'
     assert 'More information about this alert' in link.text
+
+
+def test_current_alerts_page_shows_postcode_area_alerts(
+    alert_dict,
+    client_get,
+    mocker,
+):
+    mocker.patch(
+        "app.models.alert.Alert.display_areas",
+        [
+            '4km around the postcode BD1 1EE, in Bradford',
+        ],
+    )
+    mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
+    mocker.patch("app.models.alerts.Alerts.load", return_value=Alerts([alert_dict]))
+
+    html = client_get("alerts/current-alerts")
+    titles = html.select("h2.alerts-alert__title")
+    link = html.select_one("a.govuk-body")
+
+    assert len(titles) == 1
+    assert titles[0].text.strip() == "Emergency alert sent to an area in Bradford"
+    assert "More information about this alert" in link.text
+
+
+def test_current_alerts_page_shows_decimal_coordinate_area_alerts(
+    alert_dict,
+    client_get,
+    mocker,
+):
+    mocker.patch(
+        "app.models.alert.Alert.display_areas",
+        [
+            '5km around 54.0 latitude, -2.0 longitude, in Craven',
+        ],
+    )
+    mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
+    mocker.patch("app.models.alerts.Alerts.load", return_value=Alerts([alert_dict]))
+
+    html = client_get("alerts/current-alerts")
+    titles = html.select("h2.alerts-alert__title")
+    link = html.select_one("a.govuk-body")
+
+    assert len(titles) == 1
+    assert titles[0].text.strip() == "Emergency alert sent to an area in Craven"
+    assert "More information about this alert" in link.text
+
+
+def test_current_alerts_page_shows_cartesian_coordinate_area_alerts(
+    alert_dict,
+    client_get,
+    mocker,
+):
+    mocker.patch(
+        "app.models.alert.Alert.display_areas",
+        [
+            '10km around the easting of 530111.0 and the northing of 170000.0, in Lambeth',
+        ],
+    )
+    mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
+    mocker.patch("app.models.alerts.Alerts.load", return_value=Alerts([alert_dict]))
+
+    html = client_get("alerts/current-alerts")
+    titles = html.select("h2.alerts-alert__title")
+    link = html.select_one("a.govuk-body")
+
+    assert len(titles) == 1
+    assert titles[0].text.strip() == "Emergency alert sent to an area in Lambeth"
+    assert "More information about this alert" in link.text

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -1,10 +1,9 @@
-
 from app.models.alerts import Alerts
 
 
 def test_current_alerts_page(client_get):
     html = client_get("alerts/current-alerts")
-    assert html.select_one('h1').text.strip() == "Current alerts"
+    assert html.select_one("h1").text.strip() == "Current alerts"
 
 
 def test_current_alerts_page_shows_alerts(
@@ -12,17 +11,17 @@ def test_current_alerts_page_shows_alerts(
     client_get,
     mocker,
 ):
-    mocker.patch('app.models.alert.Alert.display_areas', ['foo'])
-    mocker.patch('app.models.alert.Alert.is_current_and_public', return_value=True)
-    mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([alert_dict]))
+    mocker.patch("app.models.alert.Alert.display_areas", ["foo"])
+    mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
+    mocker.patch("app.models.alerts.Alerts.load", return_value=Alerts([alert_dict]))
 
     html = client_get("alerts/current-alerts")
-    titles = html.select('h2.alerts-alert__title')
-    link = html.select_one('a.govuk-body')
+    titles = html.select("h2.alerts-alert__title")
+    link = html.select_one("a.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == 'Emergency alert sent to Foo'
-    assert 'More information about this alert' in link.text
+    assert titles[0].text.strip() == "Emergency alert sent to Foo"
+    assert "More information about this alert" in link.text
 
 
 def test_current_alerts_page_shows_postcode_area_alerts(
@@ -33,7 +32,7 @@ def test_current_alerts_page_shows_postcode_area_alerts(
     mocker.patch(
         "app.models.alert.Alert.display_areas",
         [
-            '4km around the postcode BD1 1EE, in Bradford',
+            "4km around the postcode BD1 1EE, in Bradford",
         ],
     )
     mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
@@ -56,7 +55,7 @@ def test_current_alerts_page_shows_decimal_coordinate_area_alerts(
     mocker.patch(
         "app.models.alert.Alert.display_areas",
         [
-            '5km around 54.0 latitude, -2.0 longitude, in Craven',
+            "5km around 54.0 latitude, -2.0 longitude, in Craven",
         ],
     )
     mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
@@ -79,7 +78,7 @@ def test_current_alerts_page_shows_cartesian_coordinate_area_alerts(
     mocker.patch(
         "app.models.alert.Alert.display_areas",
         [
-            '10km around the easting of 530111.0 and the northing of 170000.0, in Lambeth',
+            "10km around the easting of 530111.0 and the northing of 170000.0 in Lambeth",
         ],
     )
     mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
@@ -91,4 +90,30 @@ def test_current_alerts_page_shows_cartesian_coordinate_area_alerts(
 
     assert len(titles) == 1
     assert titles[0].text.strip() == "Emergency alert sent to An area in Lambeth"
+    assert "More information about this alert" in link.text
+
+
+def test_current_alerts_page_shows_cartesian_coordinate_area_alerts_without_local_authority(
+    alert_dict,
+    client_get,
+    mocker,
+):
+    mocker.patch(
+        "app.models.alert.Alert.display_areas",
+        [
+            "10km around the easting of 530111.0 and the northing of 170000.0",
+        ],
+    )
+    mocker.patch("app.models.alert.Alert.is_current_and_public", return_value=True)
+    mocker.patch("app.models.alerts.Alerts.load", return_value=Alerts([alert_dict]))
+
+    html = client_get("alerts/current-alerts")
+    titles = html.select("h2.alerts-alert__title")
+    link = html.select_one("a.govuk-body")
+
+    assert len(titles) == 1
+    assert (
+        titles[0].text.strip()
+        == "Emergency alert sent to 10km around the easting of 530111.0 and the northing of 170000.0"
+    )
     assert "More information about this alert" in link.text

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -13,8 +13,8 @@ from app.utils import (
     is_in_uk,
     paragraphize,
     purge_fastly_cache,
+    simplify_custom_area_name,
     upload_html_to_s3,
-    simplify_custom_area_name
 )
 
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -14,6 +14,7 @@ from app.utils import (
     paragraphize,
     purge_fastly_cache,
     upload_html_to_s3,
+    simplify_custom_area_name
 )
 
 
@@ -31,6 +32,20 @@ def test_capitalise_capitalises_first_letter():
     text = "this is SoMe TeXt"
     expected = 'This is SoMe TeXt'
     assert capitalise(text) == expected
+
+
+def test_simplify_simplifies_custom_area_name():
+    postcode_text = "12km around the postcode HU5 5NT, in City of Kingston upon Hull"
+    postcode_expected = 'an area in City of Kingston upon Hull'
+
+    cartesian_text = "10km around the easting of 500000.0 and the northing of 180000.0, in Buckinghamshire"
+    cartesian_expected = 'an area in Buckinghamshire'
+
+    decimal_text = "10km around 52.14738 latitude, -2.803112 longitude, in County of Herefordshire"
+    decimal_expected = 'an area in County of Herefordshire'
+    assert simplify_custom_area_name(postcode_text) == postcode_expected
+    assert simplify_custom_area_name(cartesian_text) == cartesian_expected
+    assert simplify_custom_area_name(decimal_text) == decimal_expected
 
 
 def test_paragraphize_converts_newlines_to_paragraphs():

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -34,7 +34,7 @@ def test_capitalise_capitalises_first_letter():
     assert capitalise(text) == expected
 
 
-def test_simplify_simplifies_custom_area_name():
+def test_simplify_simplifies_custom_area_name_in_english():
     postcode_text = "12km around the postcode HU5 5NT, in City of Kingston upon Hull"
     postcode_expected = 'an area in City of Kingston upon Hull'
 
@@ -43,9 +43,23 @@ def test_simplify_simplifies_custom_area_name():
 
     decimal_text = "10km around 52.14738 latitude, -2.803112 longitude, in County of Herefordshire"
     decimal_expected = 'an area in County of Herefordshire'
-    assert simplify_custom_area_name(postcode_text) == postcode_expected
-    assert simplify_custom_area_name(cartesian_text) == cartesian_expected
-    assert simplify_custom_area_name(decimal_text) == decimal_expected
+    assert simplify_custom_area_name(postcode_text, 'en') == postcode_expected
+    assert simplify_custom_area_name(cartesian_text, 'en') == cartesian_expected
+    assert simplify_custom_area_name(decimal_text, 'en') == decimal_expected
+
+
+def test_simplify_simplifies_custom_area_name_in_welsh():
+    postcode_text = "12km around the postcode HU5 5NT, in City of Kingston upon Hull"
+    postcode_expected = 'ardal yn City of Kingston upon Hull'
+
+    cartesian_text = "10km around the easting of 500000.0 and the northing of 180000.0, in Buckinghamshire"
+    cartesian_expected = 'ardal yn Buckinghamshire'
+
+    decimal_text = "10km around 52.14738 latitude, -2.803112 longitude, in County of Herefordshire"
+    decimal_expected = 'ardal yn County of Herefordshire'
+    assert simplify_custom_area_name(postcode_text, 'cy') == postcode_expected
+    assert simplify_custom_area_name(cartesian_text, 'cy') == cartesian_expected
+    assert simplify_custom_area_name(decimal_text, 'cy') == decimal_expected
 
 
 def test_paragraphize_converts_newlines_to_paragraphs():


### PR DESCRIPTION
The removal of redundant detail in Custom Area names when displayed on gov.uk/alerts and the relevant tests for this. 
For example, "5km around the easting of 530111.0 and the northing of 171161.0, in Lambeth" is displayed as "an area in Lambeth".