### PR TITLE
Avoid utcnow() which is deprecated

### DIFF
--- a/app/models/alert_date.py
+++ b/app/models/alert_date.py
@@ -95,7 +95,7 @@ class AlertDate(object):
 
     @classmethod
     def now(cls):
-        return cls(datetime.datetime.utcnow())
+        return cls(datetime.datetime.now(datetime.timezone.utc))
 
     @property
     def is_today(self):


### PR DESCRIPTION
Replaced the use of the deprecated datetime.utcnow() method with
datetime.now(datetime.timezone.utc) to create an aware datetime object
representing the current UTC time.
