### PR TITLE
EAS-1055 Log broadcast-event-id with each page upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,5 +135,4 @@ run-celery: ## Run celery
 		--pidfile=/tmp/celery.pid \
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
-		--concurrency=1 \
 		--autoscale=8,1

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -9,7 +9,7 @@ from app.utils import purge_fastly_cache, upload_html_to_s3
 
 
 @notify_celery.task(bind=True, name="publish-govuk-alerts", max_retries=20, retry_backoff=True, retry_backoff_max=300)
-def publish_govuk_alerts(self, broadcast_event_id):
+def publish_govuk_alerts(self, broadcast_event_id=""):
     try:
         alerts = Alerts.load()
         rendered_pages = get_rendered_pages(alerts)

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -9,12 +9,12 @@ from app.utils import purge_fastly_cache, upload_html_to_s3
 
 
 @notify_celery.task(bind=True, name="publish-govuk-alerts", max_retries=20, retry_backoff=True, retry_backoff_max=300)
-def publish_govuk_alerts(self):
+def publish_govuk_alerts(self, broadcast_event_id):
     try:
         alerts = Alerts.load()
         rendered_pages = get_rendered_pages(alerts)
 
-        upload_html_to_s3(rendered_pages)
+        upload_html_to_s3(rendered_pages, broadcast_event_id)
         purge_fastly_cache()
     except Exception:
         current_app.logger.exception("Failed to publish content to gov.uk/alerts")

--- a/app/utils.py
+++ b/app/utils.py
@@ -78,7 +78,7 @@ def is_in_uk(simple_polygons):
     )
 
 
-def upload_html_to_s3(rendered_pages):
+def upload_html_to_s3(rendered_pages, broadcast_event_id=""):
     host_environment = os.environ.get('HOST')
 
     if (host_environment == "hosted"):
@@ -96,7 +96,12 @@ def upload_html_to_s3(rendered_pages):
     bucket_name = os.environ.get("GOVUK_ALERTS_S3_BUCKET_NAME", "test-bucket")
 
     for path, content in rendered_pages.items():
-        current_app.logger.info("Uploading " + path)
+        current_app.logger.info(
+            "Uploading " + path,
+            extra={
+                "broadcast_event_id": broadcast_event_id
+            }
+        )
         content_type = "text/xml" if path.endswith(".atom") else "text/html"
         s3.put_object(
             Body=content,

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -19,7 +19,7 @@ def test_publish_govuk_alerts(
     publish_govuk_alerts()
     mock_Alerts_load.assert_called_once()
     mock_get_rendered_pages.assert_called_once_with(mock_Alerts_load.return_value)
-    mock_upload_to_s3.assert_called_once_with(mock_get_rendered_pages.return_value)
+    mock_upload_to_s3.assert_called_once_with(mock_get_rendered_pages.return_value, "")
     mock_purge_fastly_cache.assert_called_once()
 
 


### PR DESCRIPTION
As per the docs: "The number of worker processes/threads can be changed using the --concurrency argument and defaults to the number of CPUs available on the machine."

The `--autoscale` argument keeps a minimum of 1 process, but permits scaling up to 8 processes to handle queued tasks.