### PR TITLE
EAS-2570 Prevent concurrent website uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,4 +135,5 @@ run-celery: ## Run celery
 		--pidfile=/tmp/celery.pid \
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
-		--autoscale=8,1
+		--concurrency=1 \
+		--autoscale=1,1


### PR DESCRIPTION
By ensuring that we have only one Celery worker instance, we can prevent non-deterministic uploads from near simultaneous build tasks and also ensure tasks are processing in order.