### PR TITLE
EAS-2552 Force break on long strings with no whitespace

### DIFF
--- a/app/assets/stylesheets/components/atom.scss
+++ b/app/assets/stylesheets/components/atom.scss
@@ -1,3 +1,7 @@
 .atom-feed__logo {
   height: 34.55px;
 }
+
+.atom-feed__word-wrap {
+  word-wrap: break-word;
+}

--- a/app/assets/stylesheets/feed.xsl
+++ b/app/assets/stylesheets/feed.xsl
@@ -85,7 +85,7 @@
                 <xsl:value-of select="atom:title" />
             </a>
         </h3>
-        <p class="govuk-body">
+        <p class="govuk-body atom-feed__word-wrap">
             <xsl:value-of select="atom:content" disable-output-escaping="yes" />
         </p>
         <p class="govuk-body-s">

--- a/app/assets/stylesheets/feed_cy.xsl
+++ b/app/assets/stylesheets/feed_cy.xsl
@@ -85,7 +85,7 @@
                 <xsl:value-of select="atom:title" />
             </a>
         </h3>
-        <p class="govuk-body">
+        <p class="govuk-body atom-feed__word-wrap">
             <xsl:value-of select="atom:content" disable-output-escaping="yes" />
         </p>
         <p class="govuk-body-s">


### PR DESCRIPTION
This will fix the noticeable issue on Staging, where long strings of characters without whitespace overflow the page width.