### PR TITLE
Fix govuk logo link

### DIFF
--- a/app/assets/stylesheets/feed.xsl
+++ b/app/assets/stylesheets/feed.xsl
@@ -18,7 +18,7 @@
                 <header class="govuk-header" role="banner">
                     <div class="govuk-header__container govuk-width-container">
                         <div class="govuk-header__logo atom-feed__logo-width atom-feed__logo">
-                            <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
+                            <a href="/" class="govuk-header__link govuk-header__link--homepage">
                                 <span class="govuk-header__logotype">
                                     <svg
                                         focusable="false"

--- a/app/assets/stylesheets/feed.xsl
+++ b/app/assets/stylesheets/feed.xsl
@@ -18,7 +18,10 @@
                 <header class="govuk-header" role="banner">
                     <div class="govuk-header__container govuk-width-container">
                         <div class="govuk-header__logo atom-feed__logo-width atom-feed__logo">
-                            <a href="/" class="govuk-header__link govuk-header__link--homepage">
+                            <a class="govuk-header__link govuk-header__link--homepage">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="substring-before(atom:feed/atom:link[@rel='alternate' and @type='application/html']/@href, '/alerts')" />
+                                </xsl:attribute>
                                 <span class="govuk-header__logotype">
                                     <svg
                                         focusable="false"

--- a/app/assets/stylesheets/feed_cy.xsl
+++ b/app/assets/stylesheets/feed_cy.xsl
@@ -18,7 +18,10 @@
                 <header class="govuk-header" role="banner">
                     <div class="govuk-header__container govuk-width-container">
                         <div class="govuk-header__logo atom-feed__logo-width atom-feed__logo">
-                            <a href="{{ params.homepageUrl | default('https://www.gov.uk') }}" class="govuk-header__link govuk-header__link--homepage">
+                            <a class="govuk-header__link govuk-header__link--homepage">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="substring-before(atom:feed/atom:link[@rel='alternate' and @type='application/html']/@href, '/alerts')" />
+                                </xsl:attribute>
                                 <span class="govuk-header__logotype">
                                     <svg
                                         focusable="false"

--- a/app/assets/stylesheets/feed_cy.xsl
+++ b/app/assets/stylesheets/feed_cy.xsl
@@ -18,7 +18,7 @@
                 <header class="govuk-header" role="banner">
                     <div class="govuk-header__container govuk-width-container">
                         <div class="govuk-header__logo atom-feed__logo-width atom-feed__logo">
-                            <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
+                            <a href="{{ params.homepageUrl | default('https://www.gov.uk') }}" class="govuk-header__link govuk-header__link--homepage">
                                 <span class="govuk-header__logotype">
                                     <svg
                                         focusable="false"


### PR DESCRIPTION
Logo link on Prod was incorrect - this change should link to "https://www.gov.uk" now (and also work on the lower environments).