### PR TITLE
Provide the correct MIME type for Atom/XML in local

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,20 @@
-from flask import Blueprint, current_app
+from flask import Blueprint, Response, current_app
 
 from app.models.alerts import Alerts
 from app.render import get_rendered_pages
 
-bp = Blueprint('main', __name__)
+bp = Blueprint("main", __name__)
 
 
-@bp.route('/<path:key>', methods=['GET'])
+@bp.route("/<path:key>", methods=["GET"])
 def show_page(key):
     alerts = Alerts.load()
     rendered_pages = get_rendered_pages(alerts)
 
     if key in rendered_pages:
-        return rendered_pages[key]
+        if key.endswith(".atom") or key.endswith(".xsl"):
+            return Response(rendered_pages[key], mimetype="text/xml")
+        else:
+            return rendered_pages[key]
 
     return current_app.send_static_file(key)


### PR DESCRIPTION
This fixes the stylesheets for Atom / XML rendering locally. We set a content type on the objects uploaded to S3 already. Browsers seem strict on the Content-Type before interpreting the associated sheet which results in this without:

<img width="1329" alt="image" src="https://github.com/user-attachments/assets/b5241363-578d-4e44-96e4-90be2035ec1e" />
