### PR TITLE
EAS-2548: GovUK: Call API's /acknowledge after publishing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,11 +5,10 @@ from emergency_alerts_utils import logging
 from emergency_alerts_utils.celery import NotifyCelery
 from flask import Flask, current_app
 
-from app.notify_client.alerts_api_client import AlertsApiClient
+from app.notify_client.alerts_api_client import alerts_api_client
 from app.utils import DIST
 
 notify_celery = NotifyCelery()
-alerts_api_client = AlertsApiClient()
 
 
 def create_app():

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -5,6 +5,7 @@ from flask import current_app
 from app import notify_celery
 from app.models.alerts import Alerts
 from app.render import get_rendered_pages
+from app.notify_client.alerts_api_client import alerts_api_client
 from app.utils import purge_fastly_cache, upload_html_to_s3
 
 
@@ -20,6 +21,7 @@ def publish_govuk_alerts(self, broadcast_event_id=""):
 
         upload_html_to_s3(rendered_pages, broadcast_event_id)
         purge_fastly_cache()
+        alerts_api_client.send_publish_acknowledgement()
     except Exception:
         current_app.logger.exception("Failed to publish content to gov.uk/alerts")
         self.retry(queue=current_app.config['QUEUE_NAME'])

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,12 +1,12 @@
 import time
 
+from emergency_alerts_utils.celery import TaskNames
 from flask import current_app
 
 from app import notify_celery
 from app.models.alerts import Alerts
-from app.render import get_rendered_pages
-from emergency_alerts_utils.celery import TaskNames
 from app.notify_client.alerts_api_client import alerts_api_client
+from app.render import get_rendered_pages
 from app.utils import purge_fastly_cache, upload_html_to_s3
 
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -5,11 +5,18 @@ from flask import current_app
 from app import notify_celery
 from app.models.alerts import Alerts
 from app.render import get_rendered_pages
+from emergency_alerts_utils.celery import TaskNames
 from app.notify_client.alerts_api_client import alerts_api_client
 from app.utils import purge_fastly_cache, upload_html_to_s3
 
 
-@notify_celery.task(bind=True, name="publish-govuk-alerts", max_retries=20, retry_backoff=True, retry_backoff_max=300)
+@notify_celery.task(
+    bind=True,
+    name=TaskNames.PUBLISH_GOVUK_ALERTS,
+    max_retries=20,
+    retry_backoff=True,
+    retry_backoff_max=300,
+)
 def publish_govuk_alerts(self, broadcast_event_id=""):
     try:
         alerts = Alerts.load()
@@ -27,7 +34,7 @@ def publish_govuk_alerts(self, broadcast_event_id=""):
         self.retry(queue=current_app.config['QUEUE_NAME'])
 
 
-@notify_celery.task(name="trigger-govuk-alerts-healthcheck")
+@notify_celery.task(name=TaskNames.TRIGGER_GOVUK_HEALTHCHECK)
 def trigger_govuk_alerts_healthcheck():
     try:
         time_stamp = int(time.time())

--- a/app/commands.py
+++ b/app/commands.py
@@ -2,9 +2,9 @@ import click
 from flask import cli, current_app
 
 from app.models.alerts import Alerts
+from app.notify_client.alerts_api_client import alerts_api_client
 from app.render import get_rendered_pages
 from app.utils import purge_fastly_cache, upload_assets_to_s3, upload_html_to_s3
-from app.notify_client.alerts_api_client import alerts_api_client
 
 
 def setup_commands(app):

--- a/app/commands.py
+++ b/app/commands.py
@@ -4,6 +4,7 @@ from flask import cli, current_app
 from app.models.alerts import Alerts
 from app.render import get_rendered_pages
 from app.utils import purge_fastly_cache, upload_assets_to_s3, upload_html_to_s3
+from app.notify_client.alerts_api_client import alerts_api_client
 
 
 def setup_commands(app):
@@ -17,6 +18,7 @@ def publish():
     try:
         _publish_html()
         purge_fastly_cache()
+        alerts_api_client.send_publish_acknowledgement()
     except Exception as e:
         current_app.logger.exception(f"Publish FAILED: {e}")
 
@@ -28,6 +30,7 @@ def publish_with_assets():
         _publish_html()
         _publish_assets()
         purge_fastly_cache()
+        alerts_api_client.send_publish_acknowledgement()
     except FileExistsError as e:
         current_app.logger.exception(f"Publish assets FAILED: {e}")
     except Exception as e:

--- a/app/notify_client/alerts_api_client.py
+++ b/app/notify_client/alerts_api_client.py
@@ -24,7 +24,7 @@ class AlertsApiClient(BaseAPIClient):
         return data
 
     def send_publish_acknowledgement(self):
-        return self.post(url="/govuk-alerts/acknowledge")
+        return self.post(url="/govuk-alerts/acknowledge", data={})
 
 
 alerts_api_client = AlertsApiClient()

--- a/app/notify_client/alerts_api_client.py
+++ b/app/notify_client/alerts_api_client.py
@@ -3,18 +3,23 @@ from notifications_python_client.base import BaseAPIClient
 
 
 class AlertsApiClient(BaseAPIClient):
-    TIMESTAMP_FIELDS = ["approved_at", "starts_at", "cancelled_at", "finishes_at"]
+    TIMESTAMP_FIELDS = [
+        'approved_at',
+        'starts_at',
+        'cancelled_at',
+        'finishes_at'
+    ]
 
     def __init__(self):
         super().__init__("a" * 73, "b")
 
     def init_app(self, app):
-        self.base_url = app.config["NOTIFY_API_HOST_NAME"]
-        self.api_key = app.config["NOTIFY_API_CLIENT_SECRET"]
-        self.service_id = app.config["NOTIFY_API_CLIENT_ID"]
+        self.base_url = app.config['NOTIFY_API_HOST_NAME']
+        self.api_key = app.config['NOTIFY_API_CLIENT_SECRET']
+        self.service_id = app.config['NOTIFY_API_CLIENT_ID']
 
     def get_alerts(self):
-        data = self.get(url="/govuk-alerts")["alerts"]
+        data = self.get(url='/govuk-alerts')['alerts']
 
         for alert_dict in data:
             for field in self.TIMESTAMP_FIELDS:

--- a/app/notify_client/alerts_api_client.py
+++ b/app/notify_client/alerts_api_client.py
@@ -3,23 +3,18 @@ from notifications_python_client.base import BaseAPIClient
 
 
 class AlertsApiClient(BaseAPIClient):
-    TIMESTAMP_FIELDS = [
-        'approved_at',
-        'starts_at',
-        'cancelled_at',
-        'finishes_at'
-    ]
+    TIMESTAMP_FIELDS = ["approved_at", "starts_at", "cancelled_at", "finishes_at"]
 
     def __init__(self):
         super().__init__("a" * 73, "b")
 
     def init_app(self, app):
-        self.base_url = app.config['NOTIFY_API_HOST_NAME']
-        self.api_key = app.config['NOTIFY_API_CLIENT_SECRET']
-        self.service_id = app.config['NOTIFY_API_CLIENT_ID']
+        self.base_url = app.config["NOTIFY_API_HOST_NAME"]
+        self.api_key = app.config["NOTIFY_API_CLIENT_SECRET"]
+        self.service_id = app.config["NOTIFY_API_CLIENT_ID"]
 
     def get_alerts(self):
-        data = self.get(url='/govuk-alerts')['alerts']
+        data = self.get(url="/govuk-alerts")["alerts"]
 
         for alert_dict in data:
             for field in self.TIMESTAMP_FIELDS:
@@ -27,3 +22,9 @@ class AlertsApiClient(BaseAPIClient):
                     alert_dict[field] = dt_parse(alert_dict[field])
 
         return data
+
+    def send_publish_acknowledgement(self):
+        return self.post(url="/govuk-alerts/acknowledge")
+
+
+alerts_api_client = AlertsApiClient()

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ pycurl==7.45.6
 notifications-python-client==9.1.0
 requests==2.32.3
 responses==0.25.3
-Werkzeug==3.0.3
+Werkzeug==3.1.3
 certifi==2025.4.26
 pyjwt==2.8.0
 feedgen==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -167,7 +167,7 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
-werkzeug==3.0.3
+werkzeug==3.1.3
     # via
     #   -r requirements.in
     #   flask

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -6,11 +6,13 @@ from celery.exceptions import Retry
 from app.celery.tasks import publish_govuk_alerts
 
 
-@patch('app.celery.tasks.Alerts.load')
-@patch('app.celery.tasks.get_rendered_pages')
-@patch('app.celery.tasks.upload_html_to_s3')
-@patch('app.celery.tasks.purge_fastly_cache')
+@patch("app.celery.tasks.Alerts.load")
+@patch("app.celery.tasks.get_rendered_pages")
+@patch("app.celery.tasks.upload_html_to_s3")
+@patch("app.celery.tasks.purge_fastly_cache")
+@patch("app.celery.tasks.alerts_api_client.send_publish_acknowledgement")
 def test_publish_govuk_alerts(
+    mock_send_publish_acknowledgement,
     mock_purge_fastly_cache,
     mock_upload_to_s3,
     mock_get_rendered_pages,
@@ -22,11 +24,12 @@ def test_publish_govuk_alerts(
     mock_get_rendered_pages.assert_called_once_with(mock_Alerts_load.return_value)
     mock_upload_to_s3.assert_called_once_with(mock_get_rendered_pages.return_value, "")
     mock_purge_fastly_cache.assert_called_once()
+    mock_send_publish_acknowledgement.assert_called_once()
 
 
-@patch('app.celery.tasks.Alerts.load')
-@patch('app.celery.tasks.get_rendered_pages')
-@patch('app.celery.tasks.upload_html_to_s3')
+@patch("app.celery.tasks.Alerts.load")
+@patch("app.celery.tasks.get_rendered_pages")
+@patch("app.celery.tasks.upload_html_to_s3")
 @pytest.mark.xfail(raises=Retry)
 def test_publish_govuk_alerts_retries(
     mock_upload_to_s3,
@@ -34,5 +37,5 @@ def test_publish_govuk_alerts_retries(
     mock_Alerts_load,
     govuk_alerts,
 ):
-    mock_upload_to_s3.side_effect = Exception('error')
+    mock_upload_to_s3.side_effect = Exception("error")
     publish_govuk_alerts()


### PR DESCRIPTION
> **Requires https://github.com/alphagov/emergency-alerts-utils/pull/112 and https://github.com/alphagov/emergency-alerts-api/pull/229**

As title - API will now call GovUK for naturally finished alerts and expects to receive an acknowledgement from GovUK when it has finished a publishing event.