### PR TITLE
Adjusts extended alert H2 & tests accordingly

### DIFF
--- a/app/templates/components/extended_alert.html
+++ b/app/templates/components/extended_alert.html
@@ -14,7 +14,7 @@
           </h{{ heading_level }}>
         {% else %}
           <h{{ heading_level }} class="alerts-alert__title govuk-heading-m govuk-!-margin-bottom-3">
-            <span class="govuk-visually-hidden">Emergency alert sent to </span>{{ alert.display_areas | formatted_list(before_each='', after_each='') | simplify_custom_area_name('en') |capitalise }}
+            Emergency Alert
           </h{{ heading_level }}>
         {% endif %}
         {{alert_text(alert.content)}}

--- a/tests/app/main/views/test_current_alerts.py
+++ b/tests/app/main/views/test_current_alerts.py
@@ -22,7 +22,7 @@ def test_current_alerts_page_shows_single_alert(
     body = html.select("p.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to Foo"
+    assert titles[0].text.strip() == "Emergency Alert"
     assert body[0].text.strip() == "Something"
     assert body[1].text.strip() == (
         'Sent by the UK government at 12:30pm on Wednesday 21 April 2021'
@@ -75,7 +75,7 @@ def test_current_alerts_page_shows_postcode_area_alerts(
     body = html.select("p.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to An area in Bradford"
+    assert titles[0].text.strip() == "Emergency Alert"
     assert ' '.join(
         [normalize_spaces(p.text) for p in body]
     ) == normalize_spaces(
@@ -105,7 +105,7 @@ def test_current_alerts_page_shows_decimal_coordinate_area_alerts(
     body = html.select("p.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to An area in Craven"
+    assert titles[0].text.strip() == "Emergency Alert"
     assert ' '.join(
         [normalize_spaces(p.text) for p in body]
     ) == normalize_spaces(
@@ -135,7 +135,7 @@ def test_current_alerts_page_shows_cartesian_coordinate_area_alerts(
     body = html.select("p.govuk-body")
 
     assert len(titles) == 1
-    assert titles[0].text.strip() == "Emergency alert sent to An area in Lambeth"
+    assert titles[0].text.strip() == "Emergency Alert"
     assert ' '.join(
         [normalize_spaces(p.text) for p in body]
     ) == normalize_spaces(
@@ -167,7 +167,7 @@ def test_current_alerts_page_shows_cartesian_coordinate_area_alerts_without_loca
     assert len(titles) == 1
     assert (
         titles[0].text.strip()
-        == "Emergency alert sent to 10km around the easting of 530111.0 and the northing of 170000.0"
+        == "Emergency Alert"
     )
     assert ' '.join(
         [normalize_spaces(p.text) for p in body]

--- a/tests/app/main/views/test_past_alerts.py
+++ b/tests/app/main/views/test_past_alerts.py
@@ -17,7 +17,7 @@ def test_past_alerts_page(client_get):
 @pytest.mark.parametrize('is_public,expected_title', [
     [
         True,
-        'Emergency alert sent to Foo',
+        'Emergency Alert',
     ]
 ])
 def test_past_alerts_page_shows_single_past_alert(


### PR DESCRIPTION
This PR adjusts the H2 text for the extended alert, displayed on 'Current alerts' page if there's only one current alert. The tests have also been adjusted accordingly.