### PR TITLE
EAS-2683: GovUK: Update ECS task definitions on deploy with commit image

### DIFF
--- a/.codepipeline/buildspec-govuk-deploy.yml
+++ b/.codepipeline/buildspec-govuk-deploy.yml
@@ -14,4 +14,5 @@ phases:
   build:
     commands:
       - echo Deployment started on `date`
+      - export COMMIT_ID=$(echo $COMMIT_ID | cut -c 1-7)
       - bash ./.codepipeline/deploy-service.sh --SERVICE govuk-alerts --RESOURCE_PREFIX ${RESOURCE_PREFIX:-eas-app}

--- a/.codepipeline/buildspec-govuk-deploy.yml
+++ b/.codepipeline/buildspec-govuk-deploy.yml
@@ -7,7 +7,7 @@ phases:
         if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
           echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
           git checkout $MANUAL_PIPELINE_BRANCH
-        elif [ -n "$COMMIT_ID" ]; then
+        elif [ -z "$COMMIT_ID" ]; then
           echo Checking out to govuk_${ENVIRONMENT}_latest tag...
           git checkout tags/govuk_${ENVIRONMENT}_latest
         fi


### PR DESCRIPTION
> **Requires https://github.com/alphagov/emergency-alerts-infra/pull/1383**

This is likely only temporary as it supports only the legacy pipelines. Ironically it makes the legacy unversioned pipelines, er, versioned. 🚀

...follows the same technique for Celery in the API repo.