### PR TITLE
EAS-2278 Add national test content

### DIFF
--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -42,7 +42,9 @@ class PlannedTest(SerialisedModel):
     @property
     def display_areas_in_welsh(self):
 
-        if self.areas_in_welsh and "aggregate_names" in self.areas_in_welsh:
+        if not self.areas_in_welsh:
+            return None
+        if "aggregate_names" in self.areas_in_welsh:
             return self.areas_in_welsh["aggregate_names"]
 
         return self.areas_in_welsh.get("names", [])

--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -12,9 +12,11 @@ class PlannedTest(SerialisedModel):
         'channel',
         'approved_at',
         'starts_at',
+        'starts_at_datetime_in_welsh',
         'cancelled_at',
         'finishes_at',
         'areas',
+        'areas_in_welsh',
         'display_in_status_box',
         'status_box_content',
         'welsh_status_box_content',
@@ -36,6 +38,14 @@ class PlannedTest(SerialisedModel):
             return self.areas["aggregate_names"]
 
         return self.areas.get("names", [])
+
+    @property
+    def display_areas_in_welsh(self):
+
+        if self.areas_in_welsh and "aggregate_names" in self.areas_in_welsh:
+            return self.areas_in_welsh["aggregate_names"]
+
+        return self.areas_in_welsh.get("names", [])
 
     @property
     def starts_at_date(self):

--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -22,7 +22,8 @@ class PlannedTest(SerialisedModel):
         'welsh_summary',
         'content',
         'welsh_content',
-        'display_as_link'
+        'display_as_link',
+        'extra_content'
     }
 
     def __lt__(self, other):

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -15,6 +15,8 @@
 
 {% macro announcement_banner(dates_of_test_alerts, lang='en') %}
 
+  {% set display_as_link = dates_of_test_alerts|sort(attribute='starts_at_date') | first | attr('display_as_link') %}
+
   {% set title %}
     {% for alert in dates_of_test_alerts|sort(attribute='starts_at_date') %}
       {% if loop.index == 1 %}

--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -149,9 +149,9 @@
     </p>
     <div class="govuk-inset-text govuk-!-margin-top-2">
       {% if alert_or_planned_test.welsh_content %}
-        {{ alert_or_planned_test.welsh_content | paragraphize(classes="govuk-body") }}
+        {{ alert_or_planned_test.welsh_content | autolink_urls(classes='govuk-link') | paragraphize(classes="govuk-body") }}
       {% else %}
-        {{ alert_or_planned_test.content | paragraphize(classes="govuk-body") }}
+        {{ alert_or_planned_test.content | autolink_urls(classes='govuk-link') | paragraphize(classes="govuk-body") }}
       {% endif %}
     </div>
     {% if alert_or_planned_test.extra_content %}

--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -146,5 +146,16 @@
         {{ alert_or_planned_test.content | paragraphize(classes="govuk-body") }}
       {% endif %}
     </div>
+    {% if alert_or_planned_test.extra_content %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-6">
+        Gwybodaeth Ychwanegol
+      </h2>
+      <p class="govuk-body">
+        Cymraeg
+      </p>
+      <div class="govuk-inset-text govuk-!-margin-top-2">
+        {{ alert_or_planned_test.extra_content | autolink_urls(classes='govuk-link') | paragraphize(classes="govuk-body") }}
+      </div>
+    {% endif %}
   {% endfor %}
 {% endmacro %}

--- a/app/templates/views/announcements.cy.html
+++ b/app/templates/views/announcements.cy.html
@@ -117,12 +117,20 @@
     {% endif %}
     {% if loop.first %}
       <h2 class="{% if not date_loop.first %}date-margin-top {% else %} govuk-heading-m {% endif %}">
-        {{ alert_or_planned_test.starts_at_date.datetime_as_lang }}
+        {% if alert_or_planned_test.starts_at_datetime_in_welsh %}
+          {{ alert_or_planned_test.starts_at_datetime_in_welsh }}
+        {% else %}
+          {{ alert_or_planned_test.starts_at_date.datetime_as_lang }}
+        {% endif %}
       </h2>
     {% endif %}
     <h2 class="govuk-heading-m govuk-!-margin-top-6">
       {% if alert_or_planned_test.is_public %}
-        {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+        {% if alert_or_planned_test.display_areas_in_welsh %}
+          {{ alert_or_planned_test.display_areas_in_welsh | formatted_list(conjunction="a", before_each='', after_each='') }}
+        {% else %}
+          {{ alert_or_planned_test.display_areas | formatted_list(before_each='', after_each='') }}
+        {% endif %}
       {% endif %}
     </h2>
     {% if not alert_or_planned_test.is_public %}

--- a/app/templates/views/announcements.html
+++ b/app/templates/views/announcements.html
@@ -139,7 +139,19 @@
       The alert will say:
     </p>
     <div class="govuk-inset-text govuk-!-margin-top-2">
-      {{ alert_or_planned_test.content | paragraphize(classes="govuk-body") }}
+      {{ alert_or_planned_test.content | string | autolink_urls(classes='govuk-link') | paragraphize(classes="govuk-body")}}
     </div>
+    {% if alert_or_planned_test.extra_content %}
+      <h2 class="govuk-heading-m govuk-!-margin-top-6">
+        Additional Information
+      </h2>
+      <p class="govuk-body">
+        Welsh
+      </p>
+      <div class="govuk-inset-text govuk-!-margin-top-2">
+        {{ alert_or_planned_test.extra_content | paragraphize(classes="govuk-body") }}
+      </div>
+    {% endif %}
+
   {% endfor %}
 {% endmacro %}

--- a/app/templates/views/announcements.html
+++ b/app/templates/views/announcements.html
@@ -149,7 +149,7 @@
         Welsh
       </p>
       <div class="govuk-inset-text govuk-!-margin-top-2">
-        {{ alert_or_planned_test.extra_content | paragraphize(classes="govuk-body") }}
+        {{ alert_or_planned_test.extra_content | autolink_urls(classes='govuk-link') | paragraphize(classes="govuk-body") }}
       </div>
     {% endif %}
 

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -1,17 +1,39 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
-    channel: operator
-    approved_at: 2025-09-07T15:00:00Z
-    starts_at: 2025-09-07T15:00:00Z
+    channel: severe
+    approved_at: 2025-09-07T14:00:00Z
+    starts_at: 2025-09-07T14:00:00Z
+    starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T16:00:00Z
+    finishes_at: 2025-09-07T13:30:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
-    display_as_link: False
+    display_as_link: True
     summary: ~
     welsh_summary: ~
-    content: ""
+    content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 
+
+      You do not need to take any action.
+      In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+
+      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+
+      Visit gov.uk/alerts for more information or to view this message in Welsh.
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
     welsh_content: ~
     areas: {
+      aggregate_names: [
+      "England", "Northern Ireland", "Scotland", "Wales"]
     }
+    areas_in_welsh: {
+      aggregate_names: [
+      "Lloegr", "Gogledd Iwerddon", "Yr Alban", "Chymru"]
+    }
+    extra_content: "Dyma brawf o Rybuddion Brys, gwasanaeth llywodraeth y DU a fydd yn eich rhybuddio os oes argyfwng sy'n peryglu bywyd gerllaw.
+
+      Does dim angen i chi wneud dim. Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.
+
+      Dewch o hyd i gyngor syml ac effeithiol ar sut i baratoi ar gyfer argyfyngau yn gov.uk/prepare.
+
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -1,17 +1,39 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
-    channel: operator
-    approved_at: 2025-09-07T15:00:00Z
-    starts_at: 2025-09-07T15:00:00Z
+    channel: severe
+    approved_at: 2025-09-07T14:00:00Z
+    starts_at: 2025-09-07T14:00:00Z
+    starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T16:00:00Z
+    finishes_at: 2025-09-07T13:30:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
-    display_as_link: False
+    display_as_link: True
     summary: ~
     welsh_summary: ~
-    content: ""
+    content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 
+
+      You do not need to take any action.
+      In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+
+      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+
+      Visit gov.uk/alerts for more information or to view this message in Welsh.
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
     welsh_content: ~
     areas: {
+      aggregate_names: [
+      "England", "Northern Ireland", "Scotland", "Wales"]
     }
+    areas_in_welsh: {
+      aggregate_names: [
+      "Lloegr", "Gogledd Iwerddon", "Yr Alban", "Chymru"]
+    }
+    extra_content: "Dyma brawf o Rybuddion Brys, gwasanaeth llywodraeth y DU a fydd yn eich rhybuddio os oes argyfwng sy'n peryglu bywyd gerllaw.
+
+      Does dim angen i chi wneud dim. Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.
+
+      Dewch o hyd i gyngor syml ac effeithiol ar sut i baratoi ar gyfer argyfyngau yn gov.uk/prepare.
+
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -1,17 +1,39 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
-    channel: operator
-    approved_at: 2025-09-07T15:00:00Z
-    starts_at: 2025-09-07T15:00:00Z
+    channel: severe
+    approved_at: 2025-09-07T14:00:00Z
+    starts_at: 2025-09-07T14:00:00Z
+    starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T16:00:00Z
+    finishes_at: 2025-09-07T13:30:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
-    display_as_link: False
+    display_as_link: True
     summary: ~
     welsh_summary: ~
-    content: ""
+    content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 
+
+      You do not need to take any action.
+      In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+
+      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+
+      Visit gov.uk/alerts for more information or to view this message in Welsh.
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
     welsh_content: ~
     areas: {
+      aggregate_names: [
+      "England", "Northern Ireland", "Scotland", "Wales"]
     }
+    areas_in_welsh: {
+      aggregate_names: [
+      "Lloegr", "Gogledd Iwerddon", "Yr Alban", "Chymru"]
+    }
+    extra_content: "Dyma brawf o Rybuddion Brys, gwasanaeth llywodraeth y DU a fydd yn eich rhybuddio os oes argyfwng sy'n peryglu bywyd gerllaw.
+
+      Does dim angen i chi wneud dim. Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.
+
+      Dewch o hyd i gyngor syml ac effeithiol ar sut i baratoi ar gyfer argyfyngau yn gov.uk/prepare.
+
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -3,6 +3,7 @@ planned_tests:
     channel: severe
     approved_at: 2025-09-07T14:00:00Z
     starts_at: 2025-09-07T14:00:00Z
+    starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
     finishes_at: 2025-09-07T13:30:00Z
     display_in_status_box: True
@@ -13,23 +14,26 @@ planned_tests:
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 
 
-    You do not need to take any action.
-    In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+      You do not need to take any action.
+      In a real emergency, follow the instructions in the alert to keep yourself and others safe.
 
-    Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
 
-    Visit gov.uk/alerts for more information or to view this message in Welsh.
-    Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
+      Visit gov.uk/alerts for more information or to view this message in Welsh.
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
     welsh_content: ~
     areas: {
       aggregate_names: [
       "England", "Northern Ireland", "Scotland", "Wales"]
     }
-    extra_content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby.
+    areas_in_welsh: {
+      aggregate_names: [
+      "Lloegr", "Gogledd Iwerddon", "Yr Alban", "Chymru"]
+    }
+    extra_content: "Dyma brawf o Rybuddion Brys, gwasanaeth llywodraeth y DU a fydd yn eich rhybuddio os oes argyfwng sy'n peryglu bywyd gerllaw.
 
-      You do not need to take any action. In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+      Does dim angen i chi wneud dim. Mewn argyfwng go iawn, dilynwch y cyfarwyddiadau yn y rhybudd i'ch cadw chi ac eraill yn ddiogel.
 
-      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+      Dewch o hyd i gyngor syml ac effeithiol ar sut i baratoi ar gyfer argyfyngau yn gov.uk/prepare.
 
-      Visit gov.uk/alerts for more information or to view this message in Welsh.
       Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -1,17 +1,35 @@
 planned_tests:
   - id: dd5af9c4-849a-4c23-a523-d6cbda2557d9
-    channel: operator
-    approved_at: 2025-09-07T15:00:00Z
-    starts_at: 2025-09-07T15:00:00Z
+    channel: severe
+    approved_at: 2025-09-07T14:00:00Z
+    starts_at: 2025-09-07T14:00:00Z
     cancelled_at:
-    finishes_at: 2025-09-07T16:00:00Z
+    finishes_at: 2025-09-07T13:30:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
-    display_as_link: False
+    display_as_link: True
     summary: ~
     welsh_summary: ~
-    content: ""
+    content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 
+
+    You do not need to take any action.
+    In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+
+    Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+
+    Visit gov.uk/alerts for more information or to view this message in Welsh.
+    Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."
     welsh_content: ~
     areas: {
+      aggregate_names: [
+      "England", "Northern Ireland", "Scotland", "Wales"]
     }
+    extra_content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby.
+
+      You do not need to take any action. In a real emergency, follow the instructions in the alert to keep yourself and others safe.
+
+      Find simple and effective advice on how to prepare for emergencies at gov.uk/prepare.
+
+      Visit gov.uk/alerts for more information or to view this message in Welsh.
+      Ewch i gov.uk/alerts am ragor o wybodaeth neu i weld y neges hon yn y Gymraeg."

--- a/tests/app/main/views/test_announcements.py
+++ b/tests/app/main/views/test_announcements.py
@@ -26,9 +26,9 @@ from tests import normalize_spaces
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': "This is extra content"
         })],
-        ['Wednesday 3 February 2021 at 8pm', 'Ibiza'],
+        ['Wednesday 3 February 2021 at 8pm', 'Ibiza', "Additional Information"],
         [],
         [
             'The alert will say:',
@@ -37,6 +37,8 @@ from tests import normalize_spaces
                 'service. You do not need to take any action. To find out more, '
                 'search for gov.uk/alerts'
             ),
+            'Welsh',
+            'This is extra content'
         ]
     ),
     (

--- a/tests/app/main/views/test_announcements.py
+++ b/tests/app/main/views/test_announcements.py
@@ -26,7 +26,9 @@ from tests import normalize_spaces
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': "This is extra content"
+            'extra_content': "This is extra content",
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza', "Additional Information"],
         [],
@@ -58,7 +60,9 @@ from tests import normalize_spaces
             'welsh_content': None,
             'areas': {'names': ['Ibiza', 'The Norfolk Broads']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': None,
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza and The Norfolk Broads'],
         [],
@@ -86,7 +90,9 @@ from tests import normalize_spaces
                 'welsh_content': None,
                 'areas': {'names': ['Ibiza']},
                 'display_as_link': True,
-                'extra_content': None
+                'extra_content': None,
+                'areas_in_welsh': None,
+                'starts_at_datetime_in_welsh': None
             }),
             PlannedTest({
                 'id': '5838d0d7-37eb-4ec9-87a7-5d9dc5b650c3',
@@ -104,7 +110,9 @@ from tests import normalize_spaces
                 'welsh_content': None,
                 'areas': {'names': ['The Norfolk Broads']},
                 'display_as_link': True,
-                'extra_content': None
+                'extra_content': None,
+                'areas_in_welsh': None,
+                'starts_at_datetime_in_welsh': None
             }),
         ],
         [],

--- a/tests/app/main/views/test_announcements.py
+++ b/tests/app/main/views/test_announcements.py
@@ -25,7 +25,8 @@ from tests import normalize_spaces
                        'search for gov.uk/alerts',
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza'],
         [],
@@ -54,7 +55,8 @@ from tests import normalize_spaces
             'content': 'Paragraph 1\n\nParagraph 2',
             'welsh_content': None,
             'areas': {'names': ['Ibiza', 'The Norfolk Broads']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza and The Norfolk Broads'],
         [],
@@ -81,7 +83,8 @@ from tests import normalize_spaces
                 'content': 'Paragraph 1\n\nParagraph 2',
                 'welsh_content': None,
                 'areas': {'names': ['Ibiza']},
-                'display_as_link': True
+                'display_as_link': True,
+                'extra_content': None
             }),
             PlannedTest({
                 'id': '5838d0d7-37eb-4ec9-87a7-5d9dc5b650c3',
@@ -98,7 +101,8 @@ from tests import normalize_spaces
                 'content': 'Paragraph 3\n\nParagraph 4',
                 'welsh_content': None,
                 'areas': {'names': ['The Norfolk Broads']},
-                'display_as_link': True
+                'display_as_link': True,
+                'extra_content': None
             }),
         ],
         [],

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -55,7 +55,8 @@ def test_index_page_shows_current_alerts(
                        'search for gov.uk/alerts',
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         'On Wednesday 21 April 2021 at 2PM, there will be a test of the UK Emergency Alerts service'
     ],
@@ -77,7 +78,8 @@ def test_index_page_shows_current_alerts(
                        'search for gov.uk/alerts',
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         'Status box content'
     ]

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -56,7 +56,9 @@ def test_index_page_shows_current_alerts(
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': None,
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         'On Wednesday 21 April 2021 at 2PM, there will be a test of the UK Emergency Alerts service'
     ],
@@ -79,7 +81,9 @@ def test_index_page_shows_current_alerts(
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': None,
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         'Status box content'
     ]

--- a/tests/app/main/views/test_system_testing.py
+++ b/tests/app/main/views/test_system_testing.py
@@ -36,7 +36,8 @@ def test_system_testing_page(mocker, client_get):
                        'search for gov.uk/alerts',
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         'The government and mobile network operators occasionally carry out operator tests.'
     ],
@@ -58,7 +59,8 @@ def test_system_testing_page(mocker, client_get):
                        'search for gov.uk/alerts',
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
-            'display_as_link': True
+            'display_as_link': True,
+            'extra_content': None
         })],
         'This summary should be displayed'
     ]

--- a/tests/app/main/views/test_system_testing.py
+++ b/tests/app/main/views/test_system_testing.py
@@ -37,7 +37,9 @@ def test_system_testing_page(mocker, client_get):
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': None,
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         'The government and mobile network operators occasionally carry out operator tests.'
     ],
@@ -60,7 +62,9 @@ def test_system_testing_page(mocker, client_get):
             'welsh_content': None,
             'areas': {'names': ['Ibiza']},
             'display_as_link': True,
-            'extra_content': None
+            'extra_content': None,
+            'areas_in_welsh': None,
+            'starts_at_datetime_in_welsh': None
         })],
         'This summary should be displayed'
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,9 @@ def create_planned_test_dict(
     content=None,
     welsh_content=None,
     areas=None,
-    extra_content=None
+    extra_content=None,
+    starts_at_datetime_in_welsh=None,
+    areas_in_welsh=None
 ):
     return {
         'id': id or uuid.uuid4(),
@@ -70,7 +72,9 @@ def create_planned_test_dict(
         'content': content,
         'welsh_content': welsh_content,
         "extra_content": None,
-        'display_as_link': True
+        'display_as_link': True,
+        'areas_in_welsh': areas_in_welsh or [],
+        'starts_at_datetime_in_welsh': starts_at_datetime_in_welsh or None
     }
 
 


### PR DESCRIPTION
This PR updates the planned tests yaml files to update the content within announcement banner, and to ensure the banner links to announcements page.
Additionally, if `starts_at_datetime_in_welsh`  or `areas_in_welsh` are present in `planned-tests.yaml` then they are displayed on `announcements.cy.html`, otherwise the default attributes in English are displayed.