### PR TITLE
EAS-2784 Adds link to public testing pages

### DIFF
--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -72,7 +72,7 @@
         Mae hyn yn dilyn y prawf cenedlaethol llwyddiannus cyntaf ym mis Ebrill 2023.
       </p>
       <p class="govuk-body">
-        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out">British Sign Language (BSL) and Easy Read formats.</a>
+        Mae gwybodaeth am y prawf cenedlaethol sydd ar ddod ar gael mewn <a class="govuk-link" href="/alerts/opting-out" rel="noreferrer noopener" target="_blank">fformatau Iaith Arwyddion Prydain (BSL) a Darllen Hawdd.</a>
       </p>
       <h2 class="govuk-heading-l">
           Pam fod y prawf yn cymryd lle

--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -72,7 +72,7 @@
         Mae hyn yn dilyn y prawf cenedlaethol llwyddiannus cyntaf ym mis Ebrill 2023.
       </p>
       <p class="govuk-body">
-        Mae gwybodaeth am y prawf cenedlaethol sydd ar ddod ar gael mewn <a class="govuk-link" href="/alerts/opting-out" rel="noreferrer noopener" target="_blank">fformatau Iaith Arwyddion Prydain (BSL) a Darllen Hawdd.</a>
+        Mae gwybodaeth am y prawf cenedlaethol sydd ar ddod ar gael mewn <a class="govuk-link" href="https://www.gov.uk/guidance/emergency-alerts-test-7-september-accessible-materials" rel="noreferrer noopener" target="_blank">fformatau Iaith Arwyddion Prydain (BSL) a Darllen Hawdd.</a>
       </p>
       <h2 class="govuk-heading-l">
           Pam fod y prawf yn cymryd lle

--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -71,6 +71,9 @@
       <p class="govuk-body">
         Mae hyn yn dilyn y prawf cenedlaethol llwyddiannus cyntaf ym mis Ebrill 2023.
       </p>
+      <p class="govuk-body">
+        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out">British Sign Language (BSL) and Easy Read formats.</a>
+      </p>
       <h2 class="govuk-heading-l">
           Pam fod y prawf yn cymryd lle
       </h2>

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -72,7 +72,7 @@
         This follows the first successful national test in April 2023.
       </p>
       <p class="govuk-body">
-        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out">British Sign Language (BSL) and Easy Read formats.</a>
+        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out" rel="noreferrer noopener" target="_blank">British Sign Language (BSL) and Easy Read formats.</a>
       </p>
       <h2 class="govuk-heading-l">
           Why the test is taking place

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -71,6 +71,9 @@
       <p class="govuk-body">
         This follows the first successful national test in April 2023.
       </p>
+      <p class="govuk-body">
+        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out">British Sign Language (BSL) and Easy Read formats.</a>
+      </p>
       <h2 class="govuk-heading-l">
           Why the test is taking place
       </h2>

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -72,7 +72,7 @@
         This follows the first successful national test in April 2023.
       </p>
       <p class="govuk-body">
-        Information about the upcoming national test is available in <a class="govuk-link" href="/alerts/opting-out" rel="noreferrer noopener" target="_blank">British Sign Language (BSL) and Easy Read formats.</a>
+        Information about the upcoming national test is available in <a class="govuk-link" href="https://www.gov.uk/guidance/emergency-alerts-test-7-september-accessible-materials" rel="noreferrer noopener" target="_blank">British Sign Language (BSL) and Easy Read formats.</a>
       </p>
       <h2 class="govuk-heading-l">
           Why the test is taking place

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -5,7 +5,7 @@ planned_tests:
     starts_at: 2025-09-07T14:00:00Z
     starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T13:30:00Z
+    finishes_at: 2025-09-07T14:15:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -5,7 +5,7 @@ planned_tests:
     starts_at: 2025-09-07T14:00:00Z
     starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T13:30:00Z
+    finishes_at: 2025-09-07T14:15:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -5,7 +5,7 @@ planned_tests:
     starts_at: 2025-09-07T14:00:00Z
     starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T13:30:00Z
+    finishes_at: 2025-09-07T14:15:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -5,7 +5,7 @@ planned_tests:
     starts_at: 2025-09-07T14:00:00Z
     starts_at_datetime_in_welsh: "Sul 7 Medi am 3yh"
     cancelled_at:
-    finishes_at: 2025-09-07T13:30:00Z
+    finishes_at: 2025-09-07T14:15:00Z
     display_in_status_box: True
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."


### PR DESCRIPTION
This PR adds a link regarding alternative accessible formats, to the 'Public testing' pages in English and Welsh, and adjusts the finish time for the planned-tests banner.