### PR TITLE
National test adjustments

### DIFF
--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -25,7 +25,8 @@ class PlannedTest(SerialisedModel):
         'content',
         'welsh_content',
         'display_as_link',
-        'extra_content'
+        'extra_content',
+        'planned_tests_href'
     }
 
     def __lt__(self, other):
@@ -74,3 +75,7 @@ class PlannedTest(SerialisedModel):
     def is_planned(self):
         now = datetime.now(pytz.utc)
         return self.expires_date.as_utc_datetime >= now
+
+    @property
+    def planned_tests_page(self):
+        return self.planned_tests_href or "announcements"

--- a/app/models/planned_test.py
+++ b/app/models/planned_test.py
@@ -26,7 +26,7 @@ class PlannedTest(SerialisedModel):
         'welsh_content',
         'display_as_link',
         'extra_content',
-        'planned_tests_href'
+        'planned_tests_link'
     }
 
     def __lt__(self, other):
@@ -78,4 +78,4 @@ class PlannedTest(SerialisedModel):
 
     @property
     def planned_tests_page(self):
-        return self.planned_tests_href or "announcements"
+        return self.planned_tests_link or "announcements"

--- a/app/templates/components/banner.html
+++ b/app/templates/components/banner.html
@@ -16,6 +16,7 @@
 {% macro announcement_banner(dates_of_test_alerts, lang='en') %}
 
   {% set display_as_link = dates_of_test_alerts|sort(attribute='starts_at_date') | first | attr('display_as_link') %}
+  {% set planned_tests_page = dates_of_test_alerts|sort(attribute='starts_at_date') | first | attr('planned_tests_page') %}
 
   {% set title %}
     {% for alert in dates_of_test_alerts|sort(attribute='starts_at_date') %}
@@ -34,7 +35,7 @@
   <div class="alerts-notification-banner" role="region" aria-labelledby="alerts-national-test-banner__title">
     <h2 class="alerts-notification-banner__title govuk-heading-m govuk-!-margin-bottom-1" id="alerts-national-test-banner__title">
       {% if display_as_link %}
-        <a class="govuk-link govuk-link--no-visited-state" href="/alerts/announcements{% if lang == 'cy' %}.cy{% endif %}">{{ title }}</a>
+        <a class="govuk-link govuk-link--no-visited-state" href="/alerts/{{ planned_tests_page }}{% if lang == 'cy' %}.cy{% endif %}">{{ title }}</a>
       {% else %}
         {{ title }}
       {% endif %}

--- a/app/templates/views/opting-out.cy.html
+++ b/app/templates/views/opting-out.cy.html
@@ -70,7 +70,18 @@
         Mae ffordd wahanol o <a class="govuk-link" href="/alerts/operator-testing.cy#opt-out">optio allan o rybuddion prawf gweithredydd</a>.
       </div>
       <h3 class="govuk-heading-l">
-        Ffonau iPhone ac Android
+        iPhone
+      </h3>
+      <p class="govuk-body" id="opt-out">
+        I optio allan:
+      </p>
+      <ol class="govuk-list govuk-list--bullet">
+        <li>Ewch i ‘gosodiadau’ a dewiswch y ddewislen ‘hysbysiadau’.</li>
+        <li>Sgroliwch i’r gwaelod.</li>
+        <li>Diffoddwch ‘rybuddion difrifol’ a ‘rhybuddion eithafol’.</li>
+      </ol>
+      <h3 class="govuk-heading-l">
+        Ffonau Android
       </h3>
       <p class="govuk-body" id="opt-out">
         I optio allan:

--- a/app/templates/views/opting-out.html
+++ b/app/templates/views/opting-out.html
@@ -70,7 +70,18 @@
         There’s a different way to <a class="govuk-link" href="/alerts/operator-testing#opt-out">opt out of operator test alerts</a>.
       </div>
       <h3 class="govuk-heading-l">
-        iPhones and Android phones
+        iPhone
+      </h3>
+      <p class="govuk-body" id="opt-out">
+        To opt out:
+      </p>
+      <ol class="govuk-list govuk-list--bullet">
+        <li>Go to your settings and select the ‘notifications’ menu.</li>
+        <li>Scroll to the bottom.</li>
+        <li>Turn off ‘severe alerts’ and ‘extreme alerts’.</li>
+      </ol>
+      <h3 class="govuk-heading-l">
+        Android phones
       </h3>
       <p class="govuk-body" id="opt-out">
         To opt out:

--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -63,7 +63,9 @@
           Prawf cenedlaethol ar ddod ar 7 Medi 2025
       </h2>
       <p class="govuk-body">
+        <a class="govuk-link" href="/alerts/announcements.cy">
         Bydd y llywodraeth yn cynnal prawf cenedlaethol o system Rhybuddion Argyfwng y DU ar <strong>7 Medi 2025 am 3yh</strong>.
+        </a>
       </p>
       <p class="govuk-body">
         Anfonir y rhybudd -prawf at bob ffôn symudol 4G a 5G cydweddol a thabledi cydweddol ledled y DU.

--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -63,9 +63,7 @@
           Prawf cenedlaethol ar ddod ar 7 Medi 2025
       </h2>
       <p class="govuk-body">
-        <a class="govuk-link" href="/alerts/announcements.cy">
         Bydd y llywodraeth yn cynnal prawf cenedlaethol o system Rhybuddion Argyfwng y DU ar <strong>7 Medi 2025 am 3yh</strong>.
-        </a>
       </p>
       <p class="govuk-body">
         Anfonir y rhybudd -prawf at bob ffôn symudol 4G a 5G cydweddol a thabledi cydweddol ledled y DU.

--- a/app/templates/views/public-testing.cy.html
+++ b/app/templates/views/public-testing.cy.html
@@ -66,7 +66,7 @@
         Bydd y llywodraeth yn cynnal prawf cenedlaethol o system Rhybuddion Argyfwng y DU ar <strong>7 Medi 2025 am 3yh</strong>.
       </p>
       <p class="govuk-body">
-        Anfonir y rhybudd -prawf at bob ffôn symudol 4G a 5G cydweddol a thabledi cydweddol ledled y DU.
+        Anfonir y <a class="govuk-link" href="/alerts/announcements.cy">rhybudd -prawf</a> at bob ffôn symudol 4G a 5G cydweddol a thabledi cydweddol ledled y DU.
       </p>
       <p class="govuk-body">
         Mae hyn yn dilyn y prawf cenedlaethol llwyddiannus cyntaf ym mis Ebrill 2023.

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -63,7 +63,9 @@
           Upcoming national test on 7 September 2025
       </h2>
       <p class="govuk-body">
+        <a class="govuk-link" href="/alerts/announcements">
         The government will be carrying out a national test of the UK Emergency Alerts system on <strong>7 September 2025 at 3pm</strong>.
+        </a>
       </p>
       <p class="govuk-body">
         The test alert will be sent to all compatible 4G and 5G mobile phones and compatible tablets across the UK.

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -66,7 +66,7 @@
         The government will be carrying out a national test of the UK Emergency Alerts system on <strong>7 September 2025 at 3pm</strong>.
       </p>
       <p class="govuk-body">
-        The test alert will be sent to all compatible 4G and 5G mobile phones and compatible tablets across the UK.
+        The <a class="govuk-link" href="/alerts/announcements">test alert</a> will be sent to all compatible 4G and 5G mobile phones and compatible tablets across the UK.
       </p>
       <p class="govuk-body">
         This follows the first successful national test in April 2023.

--- a/app/templates/views/public-testing.html
+++ b/app/templates/views/public-testing.html
@@ -63,9 +63,7 @@
           Upcoming national test on 7 September 2025
       </h2>
       <p class="govuk-body">
-        <a class="govuk-link" href="/alerts/announcements">
         The government will be carrying out a national test of the UK Emergency Alerts system on <strong>7 September 2025 at 3pm</strong>.
-        </a>
       </p>
       <p class="govuk-body">
         The test alert will be sent to all compatible 4G and 5G mobile phones and compatible tablets across the UK.

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -10,6 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
+    planned_tests_href: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests-dev.yaml
+++ b/planned-tests-dev.yaml
@@ -10,7 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
-    planned_tests_href: 'public-testing'
+    planned_tests_link: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -10,6 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
+    planned_tests_href: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests-preview.yaml
+++ b/planned-tests-preview.yaml
@@ -10,7 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
-    planned_tests_href: 'public-testing'
+    planned_tests_link: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -10,6 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
+    planned_tests_href: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests-staging.yaml
+++ b/planned-tests-staging.yaml
@@ -10,7 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
-    planned_tests_href: 'public-testing'
+    planned_tests_link: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -10,6 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
+    planned_tests_href: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/planned-tests.yaml
+++ b/planned-tests.yaml
@@ -10,7 +10,7 @@ planned_tests:
     status_box_content: "We are testing the UK’s Emergency Alerts system on Sunday 7 September at 3pm."
     welsh_status_box_content: "Byddwn yn profi system Rhybuddion Argyfwng y DU ar ddydd Sul 7 Medi am 3yh."
     display_as_link: True
-    planned_tests_href: 'public-testing'
+    planned_tests_link: 'public-testing'
     summary: ~
     welsh_summary: ~
     content: "This is a test of Emergency Alerts, a UK government service that will warn you if there's a life-threatening emergency nearby. 

--- a/tests/app/main/views/test_announcements.py
+++ b/tests/app/main/views/test_announcements.py
@@ -28,7 +28,8 @@ from tests import normalize_spaces
             'display_as_link': True,
             'extra_content': "This is extra content",
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza', "Additional Information"],
         [],
@@ -62,7 +63,8 @@ from tests import normalize_spaces
             'display_as_link': True,
             'extra_content': None,
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         ['Wednesday 3 February 2021 at 8pm', 'Ibiza and The Norfolk Broads'],
         [],
@@ -92,7 +94,8 @@ from tests import normalize_spaces
                 'display_as_link': True,
                 'extra_content': None,
                 'areas_in_welsh': None,
-                'starts_at_datetime_in_welsh': None
+                'starts_at_datetime_in_welsh': None,
+                'planned_tests_link': None
             }),
             PlannedTest({
                 'id': '5838d0d7-37eb-4ec9-87a7-5d9dc5b650c3',
@@ -112,7 +115,8 @@ from tests import normalize_spaces
                 'display_as_link': True,
                 'extra_content': None,
                 'areas_in_welsh': None,
-                'starts_at_datetime_in_welsh': None
+                'starts_at_datetime_in_welsh': None,
+                'planned_tests_link': None
             }),
         ],
         [],

--- a/tests/app/main/views/test_index.py
+++ b/tests/app/main/views/test_index.py
@@ -58,7 +58,8 @@ def test_index_page_shows_current_alerts(
             'display_as_link': True,
             'extra_content': None,
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         'On Wednesday 21 April 2021 at 2PM, there will be a test of the UK Emergency Alerts service'
     ],
@@ -83,7 +84,8 @@ def test_index_page_shows_current_alerts(
             'display_as_link': True,
             'extra_content': None,
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         'Status box content'
     ]

--- a/tests/app/main/views/test_system_testing.py
+++ b/tests/app/main/views/test_system_testing.py
@@ -39,7 +39,8 @@ def test_system_testing_page(mocker, client_get):
             'display_as_link': True,
             'extra_content': None,
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         'The government and mobile network operators occasionally carry out operator tests.'
     ],
@@ -64,7 +65,8 @@ def test_system_testing_page(mocker, client_get):
             'display_as_link': True,
             'extra_content': None,
             'areas_in_welsh': None,
-            'starts_at_datetime_in_welsh': None
+            'starts_at_datetime_in_welsh': None,
+            'planned_tests_link': None
         })],
         'This summary should be displayed'
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,8 @@ def create_planned_test_dict(
     areas=None,
     extra_content=None,
     starts_at_datetime_in_welsh=None,
-    areas_in_welsh=None
+    areas_in_welsh=None,
+    planned_tests_link=None
 ):
     return {
         'id': id or uuid.uuid4(),
@@ -74,7 +75,8 @@ def create_planned_test_dict(
         "extra_content": None,
         'display_as_link': True,
         'areas_in_welsh': areas_in_welsh or [],
-        'starts_at_datetime_in_welsh': starts_at_datetime_in_welsh or None
+        'starts_at_datetime_in_welsh': starts_at_datetime_in_welsh or None,
+        'planned_tests_link': planned_tests_link
     }
 
 


### PR DESCRIPTION
This PR consists of the following:
- adds the `planned_tests_link` property to PlannedTest class, sets default link to be to `announcements` page, and for the upcoming tests it is set to `public-testing` page in `planned-tests.yaml` files
- adds link to "test alert" on `public-testing` pages, to `announcements` page
- Adjusts opting out guidance