### PR TITLE
EAS-1538: GovUK: Use Alpine as Docker image base

### DIFF
--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -4,8 +4,7 @@ ARG ECS_ACCOUNT_NUMBER
 ARG RESOURCE_PREFIX=eas-app
 ARG AWS_REGION=eu-west-2
 ARG BASE_VERSION=latest
-ARG BASE_IMAGE=base-local-alpine
-#${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
+ARG BASE_IMAGE=${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
 
 FROM node:16-alpine AS node-binaries
 ARG BASE_IMAGE

--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -24,7 +24,9 @@ RUN cd $DIR_GOVUK && \
 # Create a blank configuration file
 RUN echo "" > $DIR_GOVUK/environment.sh
 
-RUN useradd -ms /bin/bash easuser && chown -R easuser:easuser $DIR_GOVUK && chown -R easuser:easuser $DIR_UTILS
+RUN adduser -D -s /bin/bash easuser && \
+    chown -R easuser:easuser $DIR_GOVUK && \
+    chown -R easuser:easuser $DIR_UTILS
 
 COPY scripts/healthcheck.sh /
 COPY scripts/start-govuk.sh /

--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -4,7 +4,19 @@ ARG ECS_ACCOUNT_NUMBER
 ARG RESOURCE_PREFIX=eas-app
 ARG AWS_REGION=eu-west-2
 ARG BASE_VERSION=latest
-FROM ${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
+ARG BASE_IMAGE=base-local-alpine
+#${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
+
+FROM node:16-alpine AS node-binaries
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS build
+
+# Migrate over our desired NodeJS version from the official Docker Node image
+# (NodeJS doesn't provide muslc binaries directly, and Alpine's packages only contain one version)
+COPY --from=node-binaries /usr/local/bin/node /usr/local/bin/
+COPY --from=node-binaries /usr/local/lib/node_modules /usr/local/lib/node_modules/
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 ARG APP_VERSION=unknown
 
@@ -14,12 +26,20 @@ ENV FLASK_APP=app.py
 # Create root directory and copy repo
 COPY . $DIR_GOVUK
 
-# Build emergency-alerts-api
+# Build emergency-alerts-govuk-alerts (requires Node)
 RUN cd $DIR_GOVUK && \
     . $VENV_GOVUK/bin/activate && \
     python$PYTHON_VERSION -m pip install --upgrade pip wheel setuptools && \
     python$PYTHON_VERSION -m pip install pycurl && \
     APP_VERSION=${APP_VERSION} make bootstrap
+# Remove node_modules as we don't need to ship any of that for runtime later
+RUN rm -rf $DIR_GOVUK/node_modules
+
+# ---------
+# We can now use a fresh base as a small final image without NodeJS
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS final
+COPY --from=build $DIR_GOVUK $DIR_GOVUK
 
 # Create a blank configuration file
 RUN echo "" > $DIR_GOVUK/environment.sh
@@ -30,8 +50,5 @@ RUN adduser -D -s /bin/bash easuser && \
 
 COPY scripts/healthcheck.sh /
 COPY scripts/start-govuk.sh /
-
-# Getting rid of our `node_modules`, because we only need them at build-time.
-RUN rm -rf $DIR_GOVUK/node_modules
 
 CMD bash /start-govuk.sh

--- a/Dockerfile.eas-govuk-alerts
+++ b/Dockerfile.eas-govuk-alerts
@@ -6,7 +6,7 @@ ARG AWS_REGION=eu-west-2
 ARG BASE_VERSION=latest
 ARG BASE_IMAGE=${ECS_ACCOUNT_NUMBER}.dkr.ecr.${AWS_REGION}.amazonaws.com/${RESOURCE_PREFIX}-base:${BASE_VERSION}
 
-FROM node:16-alpine AS node-binaries
+FROM node:22-alpine AS node-binaries
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} AS build
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || echo "")
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
 
-
 .PHONY: clean
 clean:
 	rm -rf dist/*

--- a/Makefile
+++ b/Makefile
@@ -10,88 +10,6 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || echo "")
 VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 PYTHON_EXECUTABLE_PREFIX := $(shell test -d "$${VIRTUALENV_ROOT}" && echo "$${VIRTUALENV_ROOT}/bin/" || echo "")
 
-NVM_VERSION := 0.39.7
-NODE_VERSION := 16.14.0
-
-write-source-file:
-	@if [ -f ~/.zshrc ]; then \
-		if [[ $$(cat ~/.zshrc | grep "export NVM") ]]; then \
-			cat ~/.zshrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-		else \
-			cat ~/.bashrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-		fi \
-	else \
-		cat ~/.bashrc | grep "export NVM" | sed "s/export//" > ~/.nvm-source; \
-	fi
-
-read-source-file: write-source-file
-	@if [ ! -f ~/.nvm-source ]; then \
-		echo "Source file could not be read"; \
-		exit 1; \
-	fi
-
-	@for line in $$(cat ~/.nvm-source); do \
-		export $$line; \
-	done; \
-	echo '. "$$NVM_DIR/nvm.sh"' >> ~/.nvm-source;
-
-	@if [[ "$(NVM_DIR)" == "" || ! -f "$(NVM_DIR)/nvm.sh" ]]; then \
-		mkdir -p $(HOME)/.nvm; \
-		export NVM_DIR=$(HOME)/.nvm; \
-		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
-		echo ""; \
-		$(MAKE) write-source-file; \
-		for line in $$(cat ~/.nvm-source); do \
-			export $$line; \
-		done; \
-		echo '. "$$NVM_DIR/nvm.sh"' >> ~/.nvm-source; \
-	fi
-
-	@current_nvm_version=$$(. ~/.nvm-source && nvm --version); \
-	echo "NVM Versions (current/expected): $$current_nvm_version/$(NVM_VERSION)";
-
-upgrade-node:
-	@TEMPDIR=/tmp/node-upgrade; \
-	if [[ -d $(NVM_DIR)/versions ]]; then \
-		rm -rf $$TEMPDIR; \
-		mkdir $$TEMPDIR; \
-		cp -rf $(NVM_DIR)/versions $$TEMPDIR; \
-		echo "Node versions temporarily backed up to: $$TEMPDIR"; \
-	fi; \
-	rm -rf $(NVM_DIR); \
-	$(MAKE) read-source-file; \
-	if [[ -d $$TEMPDIR/versions ]]; then \
-		cp -rf $$TEMPDIR/versions $(NVM_DIR); \
-		echo "Restored node versions from: $$TEMPDIR"; \
-	fi;
-
-.PHONY: install-nvm
-install-nvm:
-	@echo ""
-	@echo "[Install Node Version Manager]"
-	@echo ""
-
-	@if [[ "$(NVM_VERSION)" == "" ]]; then \
-		echo "NVM_VERSION cannot be empty."; \
-		exit 1; \
-	fi
-
-	@$(MAKE) read-source-file
-
-	@current_nvm_version=$$(. ~/.nvm-source && nvm --version); \
-	if [[ "$(NVM_VERSION)" != "$$current_nvm_version" ]]; then \
-		$(MAKE) upgrade-node; \
-	fi
-
-.PHONY: install-node
-install-node: install-nvm
-	@echo ""
-	@echo "[Install Node]"
-	@echo ""
-
-	@. ~/.nvm-source && nvm install $(NODE_VERSION) \
-		&& nvm use $(NODE_VERSION) \
-		&& nvm alias default $(NODE_VERSION);
 
 .PHONY: clean
 clean:
@@ -102,18 +20,18 @@ run-flask:
 	. environment.sh && flask run -p 6017
 
 .PHONY: bootstrap
-bootstrap: install-node generate-version-file
+bootstrap: generate-version-file
 	pip3 install -r requirements_local_utils.txt
-	. ~/.nvm-source && npm ci --no-audit && npm run build
+	npm ci --no-audit && npm run build
 
 .PHONY: bootstrap-for-tests
-bootstrap-for-tests: install-node generate-version-file
+bootstrap-for-tests: generate-version-file
 	pip3 install -r requirements_github_utils.txt
-	. ~/.nvm-source && npm ci --no-audit && npm run build
+	npm ci --no-audit && npm run build
 
 .PHONY: npm-audit
 npm-audit:  ## Check for vulnerabilities in NPM packages
-	. ~/.nvm-source && npm run audit
+	npm run audit
 
 .PHONY: generate-version-file
 generate-version-file: ## Generate the app/version.py file
@@ -123,7 +41,7 @@ generate-version-file: ## Generate the app/version.py file
 test:
 	isort --check-only *.py app tests
 	flake8 .
-	. ~/.nvm-source npm run lint && npm test
+	npm run lint && npm test
 	pytest tests/
 
 .PHONY: freeze-requirements


### PR DESCRIPTION
> **Requires https://github.com/alphagov/emergency-alerts-utils/pull/119**, and is a draft because we'd want versioning to go in first.

We now use the base image, add Node, run bootstrap which does both the Python dependencies but also builds the static web content with Node, and then we copy the resulting project into a fresh final image based off base/utils. Thus we don't ship Node or any packages.