### PR TITLE
Fix sort syntax in atom feed XSLT for Firefox

### DIFF
--- a/app/assets/stylesheets/feed.xsl
+++ b/app/assets/stylesheets/feed.xsl
@@ -26,7 +26,7 @@
                                 <xsl:attribute name="href">
                                     <xsl:value-of select="substring-before(atom:feed/atom:link[@rel='alternate' and @type='application/html']/@href, '/alerts')" />
                                 </xsl:attribute>
-                                
+
                                 <svg focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 60" height="30" width="162" class="govuk-header__logotype" aria-label="GOV.UK">
                                     <title>GOV.UK</title>
                                     <g>
@@ -76,7 +76,7 @@
                         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
                         <h2 class="govuk-heading-m">Recent Alerts</h2>
                         <xsl:apply-templates select="atom:feed/atom:entry">
-                            <xsl:sort select="atom:published" data-type="text()" order="descending"/>
+                            <xsl:sort select="atom:published" data-type="text" order="descending" />
                         </xsl:apply-templates>
                     </main>
                 </div>


### PR DESCRIPTION
Should fix the feed page appearing blank in Firefox, due to an XSLT typo which Chrome overlooks.

Available in my hosted env: https://d1hux4sl1zpub5.cloudfront.net/alerts/feed.atom

Should resolve https://bugzilla.mozilla.org/show_bug.cgi?id=1987368 / https://github.com/webcompat/web-bugs/issues/175872