### PR TITLE
EAS-2767: GovUK: Ignore requirements_local_utils.txt in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
+    exclude-paths:
+      # Dependabot fails completely as it contains a local path
+      - requirements_local_utils.txt
     groups:
       pip-security:
         applies-to: security-updates


### PR DESCRIPTION
See https://github.com/alphagov/emergency-alerts-govuk/network/updates/1114974142 / #427