### PR TITLE
EAS-2889: Adjust CAP XML generation for feed (includes cancellation)

### DIFF
--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -34,6 +34,18 @@ class Alert(SerialisedModel):
         return self.areas.get("names", [])
 
     @property
+    def display_areas_formatted_string(self):
+        areas = self.display_areas or []
+        if not areas:
+            return ""
+        if len(areas) == 1:
+            return areas[0]
+        if len(areas) == 2:
+            return f"{areas[0]} and {areas[1]}"
+        # 3 or more
+        return f"{', '.join(areas[:-1])} and {areas[-1]}"
+
+    @property
     def approved_at_date(self):
         return AlertDate(self.approved_at)
 

--- a/app/models/alert.py
+++ b/app/models/alert.py
@@ -34,18 +34,6 @@ class Alert(SerialisedModel):
         return self.areas.get("names", [])
 
     @property
-    def display_areas_formatted_string(self):
-        areas = self.display_areas or []
-        if not areas:
-            return ""
-        if len(areas) == 1:
-            return areas[0]
-        if len(areas) == 2:
-            return f"{areas[0]} and {areas[1]}"
-        # 3 or more
-        return f"{', '.join(areas[:-1])} and {areas[-1]}"
-
-    @property
     def approved_at_date(self):
         return AlertDate(self.approved_at)
 

--- a/app/render.py
+++ b/app/render.py
@@ -355,13 +355,12 @@ def get_cap_xml_for_alerts(alerts, publish_task_progress=None):
 
         # If alert has been cancelled, generate another CAP XML file for the updated event
         if alert.cancelled_at:
-            new_identifier = str(uuid.uuid4())
             event = create_cap_event(
                 alert,
-                new_identifier,
+                f"{identifier}-1",
                 url=alert_url_with_host,
                 cancelled=True,
-                prev_alert_identifier=identifier
+                prev_alert_identifier=identifier,
             )
             cap_xml = generate_xml_body(event)
             timestamp = alert.cancelled_at.strftime("%Y%m%d%H%M%S")

--- a/app/render.py
+++ b/app/render.py
@@ -351,14 +351,14 @@ def get_cap_xml_for_alerts(alerts, publish_task_progress=None):
         event = create_cap_event(alert, identifier, url=alert_url_with_host)
         cap_xml = generate_xml_body(event)
         timestamp = alert.approved_at.strftime("%Y%m%d%H%M%S")
-        cap_xml_alerts[f"alerts/{alert_url}-{timestamp}.cap.xml"] = cap_xml
+        cap_xml_alerts[f"cap-xml/{alert_url}-{timestamp}.cap.xml"] = cap_xml
 
         # If alert has been cancelled, generate another CAP XML file for the updated event
         if alert.cancelled_at:
             event = create_cap_event(alert, identifier, url=alert_url_with_host, cancelled=True)
             cap_xml = generate_xml_body(event)
             timestamp = alert.cancelled_at.strftime("%Y%m%d%H%M%S")
-            cap_xml_alerts[f"alerts/{alert_url}-{timestamp}.cap.xml"] = cap_xml
+            cap_xml_alerts[f"cap-xml/{alert_url}-{timestamp}.cap.xml"] = cap_xml
 
         update_publish_progress_if_exists(publish_task_progress, f"CAP XML for {alert.id}")
 

--- a/app/render.py
+++ b/app/render.py
@@ -355,7 +355,14 @@ def get_cap_xml_for_alerts(alerts, publish_task_progress=None):
 
         # If alert has been cancelled, generate another CAP XML file for the updated event
         if alert.cancelled_at:
-            event = create_cap_event(alert, identifier, url=alert_url_with_host, cancelled=True)
+            new_identifier = str(uuid.uuid4())
+            event = create_cap_event(
+                alert,
+                new_identifier,
+                url=alert_url_with_host,
+                cancelled=True,
+                prev_alert_identifier=identifier
+            )
             cap_xml = generate_xml_body(event)
             timestamp = alert.cancelled_at.strftime("%Y%m%d%H%M%S")
             cap_xml_alerts[f"cap-xml/{alert_url}-{timestamp}.cap.xml"] = cap_xml

--- a/app/utils.py
+++ b/app/utils.py
@@ -257,14 +257,14 @@ def post_version_to_cloudwatch():
         )
 
 
-def create_cap_event(alert, identifier, url=None, cancelled=False):
-    return {
+def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_identifier=None):
+    alert = {
         "identifier": identifier,
         "message_type": "alert",
         "message_format": "cap",
         "headline": "GOV.UK Emergency alert",
         "description": alert.content,
-        "language": "en-GB",
+        "language": "en",
         "areas": [
             {
                 "polygon": polygons,
@@ -273,13 +273,18 @@ def create_cap_event(alert, identifier, url=None, cancelled=False):
         ],
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),
-        "expires": (
-            alert.cancelled_at.isoformat(timespec="seconds")
-            if cancelled
-            else alert.finishes_at.isoformat(timespec="seconds")
-        ),
+        "expires": alert.finishes_at.isoformat(timespec="seconds"),
         "web": url,
     }
+
+    if cancelled:
+        alert["references"] = [
+            {
+                "message_id": prev_alert_identifier,
+                "sent": alert.starts_at.isoformat(timespec="seconds"),
+            }
+        ]
+    return alert
 
 
 def create_publish_progress_task_id(publish_type, publish_origin):

--- a/app/utils.py
+++ b/app/utils.py
@@ -258,7 +258,7 @@ def post_version_to_cloudwatch():
 
 
 def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_identifier=None):
-    alert = {
+    cap_dict = {
         "identifier": identifier,
         "message_type": "alert",
         "message_format": "cap",
@@ -273,18 +273,22 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         ],
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),
-        "expires": alert.finishes_at.isoformat(timespec="seconds"),
+        "expires": (
+            alert.cancelled_at.isoformat(timespec="seconds")
+            if cancelled
+            else alert.finishes_at.isoformat(timespec="seconds")
+        ),
         "web": url,
     }
 
     if cancelled:
-        alert["references"] = [
+        cap_dict["references"] = [
             {
                 "message_id": prev_alert_identifier,
                 "sent": alert.starts_at.isoformat(timespec="seconds"),
             }
         ]
-    return alert
+    return cap_dict
 
 
 def create_publish_progress_task_id(publish_type, publish_origin):

--- a/app/utils.py
+++ b/app/utils.py
@@ -267,7 +267,7 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         "language": "en",
         "areas": [{
             "polygons": [polygons for polygons in alert.areas.get("simple_polygons")],
-            **({"description": alert.display_areas_formatted_string} if alert.display_areas else {})
+            **({"description": alert.display_areas} if alert.display_areas else {})
         }],
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),

--- a/app/utils.py
+++ b/app/utils.py
@@ -267,7 +267,7 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         "language": "en",
         "areas": [{
             "polygons": [polygons for polygons in alert.areas.get("simple_polygons")],
-            **({"description": alert.display_areas} if alert.display_areas else {})
+            **({"description": alert.display_areas_formatted_string} if alert.display_areas else {})
         }],
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),

--- a/app/utils.py
+++ b/app/utils.py
@@ -260,7 +260,7 @@ def post_version_to_cloudwatch():
 def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_identifier=None):
     cap_dict = {
         "identifier": identifier,
-        "message_type": "alert",
+        "message_type": "cancel" if cancelled else "alert",
         "message_format": "cap",
         "headline": "GOV.UK Emergency alert",
         "description": alert.content,

--- a/app/utils.py
+++ b/app/utils.py
@@ -265,9 +265,10 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         "headline": "GOV.UK Emergency alert",
         "description": alert.content,
         "language": "en",
-        "areas": {
+        "areas": [{
             "polygons": [polygons for polygons in alert.areas.get("simple_polygons")],
-        },
+            **({"description": alert.display_areas_formatted_string} if alert.display_areas else {})
+        }],
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),
         "expires": (
@@ -277,9 +278,6 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         ),
         "web": url,
     }
-
-    if alert.display_areas:
-        cap_dict["areas"]["description"] = alert.display_areas_formatted_string
 
     if cancelled:
         cap_dict["references"] = [

--- a/app/utils.py
+++ b/app/utils.py
@@ -265,12 +265,9 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         "headline": "GOV.UK Emergency alert",
         "description": alert.content,
         "language": "en",
-        "areas": [
-            {
-                "polygon": polygons,
-            }
-            for polygons in alert.areas.get("simple_polygons")
-        ],
+        "areas": {
+            "polygons": [polygons for polygons in alert.areas.get("simple_polygons")],
+        },
         "channel": "severe",
         "sent": alert.starts_at.isoformat(timespec="seconds"),
         "expires": (
@@ -280,6 +277,9 @@ def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_id
         ),
         "web": url,
     }
+
+    if alert.display_areas:
+        cap_dict["areas"]["description"] = alert.display_areas_formatted_string
 
     if cancelled:
         cap_dict["references"] = [

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -133,7 +133,11 @@ def test_purge_fastly_cache_disabled(mock_requests, monkeypatch, govuk_alerts):
 
 
 def test_create_cap_event_for_active_alert():
-    alert = Alert(create_alert_dict(areas={"simple_polygons": [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]}))
+    alert = Alert(
+        create_alert_dict(areas={
+            "simple_polygons": [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]],
+            "aggregate_names": "England, Scotland and Wales"
+        }))
     assert create_cap_event(alert, alert.id) == {
         'identifier': alert.id,
         'message_type': 'alert',
@@ -145,8 +149,9 @@ def test_create_cap_event_for_active_alert():
             {
                 "polygons": [
                     polygons for polygons in alert.areas.get("simple_polygons")
-                ]
-            }
+                ],
+                "description": alert.display_areas
+            },
         ],
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -140,7 +140,7 @@ def test_create_cap_event_for_active_alert():
         'message_format': 'cap',
         'headline': 'GOV.UK Emergency alert',
         'description': alert.content,
-        'language': 'en-GB',
+        'language': 'en',
         "areas": [
             {
                 "polygon": polygons,
@@ -162,7 +162,7 @@ def test_create_cap_event_for_cancelled_alert():
         'message_format': 'cap',
         'headline': 'GOV.UK Emergency alert',
         'description': alert.content,
-        'language': 'en-GB',
+        'language': 'en',
         'areas': [
             {
                 "polygon": polygons,
@@ -187,7 +187,7 @@ def test_create_cap_event_with_and_without_web_element(url):
         'message_format': 'cap',
         'headline': 'GOV.UK Emergency alert',
         'description': alert.content,
-        'language': 'en-GB',
+        'language': 'en',
         "areas": [
             {
                 "polygon": polygons,

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -143,8 +143,10 @@ def test_create_cap_event_for_active_alert():
         'language': 'en',
         "areas": [
             {
-                "polygon": polygons,
-            } for polygons in alert.areas.get("simple_polygons")
+                "polygons": [
+                    polygons for polygons in alert.areas.get("simple_polygons")
+                ]
+            }
         ],
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),
@@ -165,8 +167,10 @@ def test_create_cap_event_for_cancelled_alert():
         'language': 'en',
         'areas': [
             {
-                "polygon": polygons,
-            } for polygons in alert.areas.get("simple_polygons")
+                "polygons": [
+                    polygons for polygons in alert.areas.get("simple_polygons")
+                ]
+            }
         ],
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),
@@ -196,8 +200,10 @@ def test_create_cap_event_with_and_without_web_element(url):
         'language': 'en',
         "areas": [
             {
-                "polygon": polygons,
-            } for polygons in alert.areas.get("simple_polygons")
+                "polygons": [
+                    polygons for polygons in alert.areas.get("simple_polygons")
+                    ]
+            }
         ],
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -156,7 +156,7 @@ def test_create_cap_event_for_active_alert():
 def test_create_cap_event_for_cancelled_alert():
     alert = Alert(create_alert_dict(areas={"simple_polygons": [[[1, 2], [3, 4], [5, 6]],
                                                                [[7, 8], [9, 10], [11, 12]]]}))
-    assert create_cap_event(alert, alert.id, cancelled=True) == {
+    assert create_cap_event(alert, alert.id, cancelled=True, prev_alert_identifier=alert.id) == {
         'identifier': alert.id,
         'message_type': 'alert',
         'message_format': 'cap',
@@ -171,7 +171,13 @@ def test_create_cap_event_for_cancelled_alert():
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),
         'expires': alert.cancelled_at.isoformat(),  # Expires timestamp is for when the alert was cancelled
-        'web': None
+        'web': None,
+        'references': [
+            {
+                'message_id': alert.id,
+                'sent': alert.starts_at.isoformat()
+            }
+        ]
     }
 
 

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -136,7 +136,7 @@ def test_create_cap_event_for_active_alert():
     alert = Alert(
         create_alert_dict(areas={
             "simple_polygons": [[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]],
-            "aggregate_names": "England, Scotland and Wales"
+            "aggregate_names": ["England", "Scotland", "Wales"]
         }))
     assert create_cap_event(alert, alert.id) == {
         'identifier': alert.id,
@@ -150,7 +150,7 @@ def test_create_cap_event_for_active_alert():
                 "polygons": [
                     polygons for polygons in alert.areas.get("simple_polygons")
                 ],
-                "description": alert.display_areas
+                "description": alert.display_areas_formatted_string
             },
         ],
         'channel': 'severe',

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -158,7 +158,7 @@ def test_create_cap_event_for_cancelled_alert():
                                                                [[7, 8], [9, 10], [11, 12]]]}))
     assert create_cap_event(alert, alert.id, cancelled=True, prev_alert_identifier=alert.id) == {
         'identifier': alert.id,
-        'message_type': 'alert',
+        'message_type': 'cancel',
         'message_format': 'cap',
         'headline': 'GOV.UK Emergency alert',
         'description': alert.content,


### PR DESCRIPTION
This PR consists of the following:
- Adjustment to the CAP cancel alert generation functionality - resulting in CAP XML with `references` element to link back to previous alert
- Addition of functionality populating the `areaDesc` element with the Alert's`display_areas` text
- Adjustment to `area` element generation - now one area may have multiple polygons so the `areaDesc` is relevant for entire area
- Removes local from `language` element - as instructed during Alert Hub call
- CAP XML files published to different directory from other files