### PR TITLE
EAS-3021: Sources `sender` value for CAP XML from environment variable or provided

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ from kombu import Exchange, Queue
 class Config():
     HOST = os.environ.get('HOST')
     GOVUK_ALERTS_HOST_URL = os.environ.get("GOVUK_ALERTS_HOST_URL", "")
+    CAP_XML_SENDER_EMAIL = os.environ.get("CAP_XML_SENDER_EMAIL", "")
 
     EAS_APP_NAME = "govuk-alerts"
 
@@ -99,6 +100,7 @@ class Hosted(Config):
 class Test(Config):
     DEBUG = True
     GOVUK_ALERTS_HOST_URL = os.environ.get("GOVUK_ALERTS_HOST_URL", "http://localhost:6017")
+    CAP_XML_SENDER_EMAIL = "test@digital.cabinet-office.gov.uk"
 
     FASTLY_SERVICE_ID = "test-service-id"
     FASTLY_API_KEY = "test-api-key"

--- a/app/utils.py
+++ b/app/utils.py
@@ -257,9 +257,11 @@ def post_version_to_cloudwatch():
         )
 
 
-def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_identifier=None):
+def create_cap_event(alert, identifier, url=None, cancelled=False, prev_alert_identifier=None, sender=None):
+    sender_email = current_app.config["CAP_XML_SENDER_EMAIL"]
     cap_dict = {
         "identifier": identifier,
+        "sender": sender or sender_email,
         "message_type": "cancel" if cancelled else "alert",
         "message_format": "cap",
         "headline": "GOV.UK Emergency alert",

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -156,7 +156,8 @@ def test_create_cap_event_for_active_alert():
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),
         'expires': alert.finishes_at.isoformat(),  # Expires timestamp is for when the alert is projected to finish
-        'web': None
+        'web': None,
+        'sender': current_app.config["CAP_XML_SENDER_EMAIL"]
     }
 
 
@@ -186,7 +187,8 @@ def test_create_cap_event_for_cancelled_alert():
                 'message_id': alert.id,
                 'sent': alert.starts_at.isoformat()
             }
-        ]
+        ],
+        'sender': current_app.config["CAP_XML_SENDER_EMAIL"]
     }
 
 
@@ -213,5 +215,6 @@ def test_create_cap_event_with_and_without_web_element(url):
         'channel': 'severe',
         'sent': alert.starts_at.isoformat(),
         'expires': alert.finishes_at.isoformat(),
-        'web': url
+        'web': url,
+        'sender': current_app.config["CAP_XML_SENDER_EMAIL"]
     }


### PR DESCRIPTION
This PR consists of changes regarding the CAP XML generation, specifically setting the `sender` element value to either what has been provided (will possibly be provided in the future), else use the default which is sourced from config.