### PR TITLE
EAS-3067: GovUK: Patch CI utils based upon PR description

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           PR_UTILS_BRANCH=$(echo "$PR_DESCRIPTION" | grep -oP '`utils:\K[^`]+' || true)
 
-          if [[ -n $var ]]; then
+          if [[ -n $PR_UTILS_BRANCH ]]; then
             echo "Going to use branch $PR_UTILS_BRANCH for utils"
             sed -i s/emergency-alerts-utils\.git/emergency-alerts-utils.git@$PR_UTILS_BRANCH/ requirements_github_utils.txt
             cat requirements_github_utils.txt

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -28,12 +28,20 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install and upgrade pre-requisites
+      - name: Use specified utils version in PR
+        env:
+          PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+        # Match `utils:blah` and get the blah
         run: |
-          python${{ env.PYTHON_VERSION }} -m pip install --upgrade pip wheel setuptools
-          sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
-          sudo apt-get install -y libssl-dev
+          PR_UTILS_BRANCH=$(echo "$PR_DESCRIPTION" | grep -oP '`utils:\K[^`]+' || true)
+
+          if [[ -n $var ]]; then
+            echo "Going to use branch $PR_UTILS_BRANCH for utils"
+            sed -i s/emergency-alerts-utils\.git/emergency-alerts-utils.git@$PR_UTILS_BRANCH/ requirements_github_utils.txt
+            cat requirements_github_utils.txt
+          else
+            echo "Leaving utils target as default"
+          fi
 
       - name: Bootstrap Python app and run tests
         run: |

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Use specified utils version in PR
         env:
           PR_DESCRIPTION: ${{ github.event.pull_request.body }}
-        # Match `utils:blah` and get the blah
+        # Match `utils:blah` and capture the blah
         run: |
           PR_UTILS_BRANCH=$(echo "$PR_DESCRIPTION" | grep -oP '`utils:\K[^`]+' || true)
 

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -37,7 +37,7 @@ jobs:
 
           if [[ -n $PR_UTILS_BRANCH ]]; then
             echo "Going to use branch $PR_UTILS_BRANCH for utils"
-            sed -i "s/emergency-alerts-utils\.git/emergency-alerts-utils.git@$PR_UTILS_BRANCH/" requirements_github_utils.txt
+            sed -i "s|emergency-alerts-utils\.git|emergency-alerts-utils.git@$PR_UTILS_BRANCH|" requirements_github_utils.txt
             cat requirements_github_utils.txt
           else
             echo "Leaving utils target as default"

--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -37,7 +37,7 @@ jobs:
 
           if [[ -n $PR_UTILS_BRANCH ]]; then
             echo "Going to use branch $PR_UTILS_BRANCH for utils"
-            sed -i s/emergency-alerts-utils\.git/emergency-alerts-utils.git@$PR_UTILS_BRANCH/ requirements_github_utils.txt
+            sed -i "s/emergency-alerts-utils\.git/emergency-alerts-utils.git@$PR_UTILS_BRANCH/" requirements_github_utils.txt
             cat requirements_github_utils.txt
           else
             echo "Leaving utils target as default"


### PR DESCRIPTION
This introduces a simple mechanism to override the utils branch used while running in CI, allowing dependent utils changes to be brought in to run tests (etc) without making a mess of the actual Git PR contents for reviews.

This can be invoked by putting utils:my-branch-name surrounded by `backticks` anywhere in the PR description. See the prior runs and edit history here if you're curious - I pointed it at Dramatiq's util branch and naturally CI broke here as expected because it needs Celery.