### PR TITLE
GovUK: Tweak start script to avoid warning if AWS_REGION is unset

### DIFF
--- a/run_celery.py
+++ b/run_celery.py
@@ -1,9 +1,0 @@
-import logging
-
-from app import create_app, notify_celery  # noqa
-
-application = create_app()
-application.app_context().push()
-
-logger = logging.getLogger(__name__)
-logger.info("run_celery init")

--- a/scripts/start-govuk.sh
+++ b/scripts/start-govuk.sh
@@ -3,7 +3,7 @@ timestamp_filename='/eas/emergency-alerts-govuk/celery-beat-healthcheck'
 echo "Start script executing for govuk-alerts"
 
 function configure_container_role(){
-    aws configure set default.region ${AWS_REGION}
+    aws configure set default.region ${AWS_REGION:-eu-west-2}
 }
 
 function run_dramatiq(){


### PR DESCRIPTION
This aligns the start script with other repos, which otherwise causes an AWS CLI warning upon startup in localenv.

Truth be told I don't know why we have this everywhere anyway. The environment variables provided by Fargate should be good enough for region discovery (i.e. it sets `AWS_REGION` and we just let the SDK discover things)? Or I could be totally wrong?

I'm assuming it's a leftover from PaaS many moons ago perhaps.