### PR TITLE
EAS-3129 Fix escape boundary in atom renderer

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -314,9 +314,6 @@ def _add_stopped_time_to_content(alert):
     # attacker-influenceable (GSM-7 allows <, >, & and quotes) and MUST be XML-escaped
     # before interpolation, otherwise it can inject markup into feed readers or break the
     # whole feed when lxml re-parses it in _add_stylesheet_attribute_to_atom.
-    # NB: alerts created via the admin "create" path are already HTML-escaped in storage,
-    # so this escape double-escapes those (cosmetic only); resolving that needs the wider
-    # storage-consistency work that is intentionally out of scope here.
     escaped_content = escape(alert.content)
     if alert.is_past:
         broadcast_status = "Stopped sending at "

--- a/app/render.py
+++ b/app/render.py
@@ -15,6 +15,7 @@ from jinja2 import (
     pass_context,
 )
 from lxml import etree as ET
+from markupsafe import escape
 
 from app.models.publish_task_progress import update_publish_progress_if_exists
 from app.utils import (
@@ -308,6 +309,15 @@ def _add_javascript_link_to_xsl(xsl_content):
 
 
 def _add_stopped_time_to_content(alert):
+    # The feed entry is emitted with type="xhtml", so the content string must be a
+    # well-formed XHTML fragment whose only markup is server-generated. alert.content is
+    # attacker-influenceable (GSM-7 allows <, >, & and quotes) and MUST be XML-escaped
+    # before interpolation, otherwise it can inject markup into feed readers or break the
+    # whole feed when lxml re-parses it in _add_stylesheet_attribute_to_atom.
+    # NB: alerts created via the admin "create" path are already HTML-escaped in storage,
+    # so this escape double-escapes those (cosmetic only); resolving that needs the wider
+    # storage-consistency work that is intentionally out of scope here.
+    escaped_content = escape(alert.content)
     if alert.is_past:
         broadcast_status = "Stopped sending at "
         if alert.cancelled_at and (alert.cancelled_at < alert.finishes_at):
@@ -316,11 +326,15 @@ def _add_stopped_time_to_content(alert):
             broadcast_status += _readable_time_string(alert.finishes_at)
         return (
             "<div xmlns='http://www.w3.org/1999/xhtml'>"
-            f"<p><strong>{broadcast_status}</strong></p>"
-            f"<p><![CDATA[{alert.content}]]></p>"
+            f"<p><strong>{escape(broadcast_status)}</strong></p>"
+            f"<p>{escaped_content}</p>"
             "</div>"
         )
-    return alert.content
+    return (
+        "<div xmlns='http://www.w3.org/1999/xhtml'>"
+        f"<p>{escaped_content}</p>"
+        "</div>"
+    )
 
 
 def _build_readable_summary(title, alert):

--- a/tests/app/test_render.py
+++ b/tests/app/test_render.py
@@ -9,6 +9,7 @@ from dateutil.parser import parse as dt_parse
 from app.models.alert import Alert
 from app.models.alerts import Alerts
 from app.render import (
+    _add_stopped_time_to_content,
     get_cap_xml_for_alerts,
     get_rendered_pages,
     get_url_for_alert,
@@ -171,6 +172,75 @@ def test_get_rendered_pages_generates_atom_feed(govuk_alerts):
     assert len(entries) == 5
 
     _verify_entries(entries, namespace, expected_feed_items)
+
+
+# A payload that would inject markup / break the XML if not escaped: opening tags, an
+# ampersand, and the literal CDATA terminator that the old code used as an "escaping" boundary.
+HOSTILE_CONTENT = '<script>alert(1)</script> & ]]> end'
+
+
+def test_add_stopped_time_to_content_escapes_hostile_content_for_past_alert():
+    # Default create_alert_dict is expired + cancelled, so the alert is "past".
+    alert = Alert(create_alert_dict(content=HOSTILE_CONTENT))
+    assert alert.is_past
+
+    result = _add_stopped_time_to_content(alert)
+
+    # Server-generated formatting is preserved...
+    assert 'Stopped sending at ' in result
+    assert '<strong>' in result
+    # ...but the alert content is XML-escaped, with no live tag and no CDATA break-out.
+    assert '&lt;script&gt;alert(1)&lt;/script&gt;' in result
+    assert '<script>' not in result
+    assert '<![CDATA[' not in result
+    assert '&amp;' in result
+    # The fragment is well-formed XHTML (this is what feedgen must be able to parse).
+    ET.fromstring(result)
+
+
+def test_add_stopped_time_to_content_escapes_hostile_content_for_current_alert():
+    # A future finishes_at with no cancellation makes the alert current (not past).
+    alert = Alert(create_alert_dict(
+        content=HOSTILE_CONTENT,
+        cancelled_at=None,
+        finishes_at=dt_parse('2099-01-01T00:00:00Z'),
+    ))
+    assert not alert.is_past
+
+    result = _add_stopped_time_to_content(alert)
+
+    # Current alerts carry no "Stopped sending at" status, but content is still escaped
+    # and wrapped in a single well-formed XHTML root (previously it was a bare string).
+    assert 'Stopped sending at ' not in result
+    assert '&lt;script&gt;alert(1)&lt;/script&gt;' in result
+    assert '<script>' not in result
+    ET.fromstring(result)
+
+
+def test_get_rendered_pages_feed_stays_well_formed_with_hostile_content(govuk_alerts):
+    # A single alert whose content contains XML-significant characters must not break the
+    # whole feed (the assembled feed is re-parsed by lxml in _add_stylesheet_attribute_to_atom).
+    alerts = [
+        create_alert_dict(
+            id=UUID(int=0),
+            content=HOSTILE_CONTENT,
+            starts_at=dt_parse('2021-04-21T11:30:00Z'),
+            approved_at=dt_parse('2021-04-21T11:25:00Z'),
+        ),
+    ]
+
+    pages = get_rendered_pages(Alerts(alerts))
+
+    # Reaching here already proves the lxml round-trip did not raise on malformed XML.
+    namespace = {'atom': 'http://www.w3.org/2005/Atom'}
+    for feed_path in ('alerts/feed.atom', 'alerts/feed_cy.atom'):
+        feed_str = pages[feed_path]
+        # No live <script> tag leaks into the served feed; the payload is escaped.
+        assert '<script>' not in feed_str
+        assert '&lt;script&gt;' in feed_str
+        # The feed as a whole is parseable.
+        root = ET.fromstring(feed_str)
+        assert len(root.findall('atom:entry', namespace)) == 1
 
 
 def _cut_off_alerts():


### PR DESCRIPTION
This PR fixes the emergency-alerts Atom feed XSS/malformed-XML vulnerability by escaping alert content in emergency-alerts-govuk's render.py