### PR TITLE
Revert "fix: Alert content escape (#538)"

### DIFF
--- a/app/templates/components/alert_text.html
+++ b/app/templates/components/alert_text.html
@@ -1,5 +1,5 @@
 {% macro alert_text(text, truncate=False) %}
 <div>
-  {{ text | string | e | autolink_urls(classes='govuk-link') | paragraphize(truncate=truncate, escape_content=False) }}
+  {{ text | string | autolink_urls(classes='govuk-link') | paragraphize(truncate=truncate) }}
 </div>
 {% endmacro %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -50,16 +50,14 @@ def is_custom_area_with_local_authority(value):
     )
 
 
-def paragraphize(value, classes="govuk-body govuk-!-margin-bottom-4", truncate=False, escape_content=True):
-    if escape_content:
-        value = escape(value)
+def paragraphize(value, classes="govuk-body govuk-!-margin-bottom-4", truncate=False):
     if truncate:
         paragraphs = f'<p class="{classes} truncated-text">{value}</p>'
         return Markup(paragraphs)
     else:
         paragraphs = [
             f'<p class="{classes}">{line}</p>'
-            for line in value.split('\n')
+            for line in escape(value).split('\n')
             if line
         ]
         return Markup('\n\n'.join(paragraphs))

--- a/tests/app/main/views/test_alert.py
+++ b/tests/app/main/views/test_alert.py
@@ -124,31 +124,3 @@ def test_alert_no_extra_content(client_get, mocker):
 
     html = client_get('alerts/21-apr-2021')
     assert not html.select_one('#extra-content')
-
-
-@pytest.mark.parametrize('malicious_content', [
-    '<script>alert("xss")</script>',
-    '<img src=x onerror=alert(1)>',
-    '<a href="javascript:alert(1)">click</a>',
-    '"><svg onload=alert(1)>',
-])
-def test_alert_content_with_html_is_escaped(client_get, mocker, malicious_content):
-    mocker.patch('app.models.alerts.Alerts.load', return_value=Alerts([
-        create_alert_dict(
-            id=uuid4(),
-            content=malicious_content,
-            starts_at=dt_parse('2021-04-21T11:00:00Z'),
-        )
-    ]))
-
-    html = client_get('alerts/21-apr-2021')
-
-    alert_paragraphs = html.select('p.govuk-body')
-    assert len(alert_paragraphs) > 0
-
-    for paragraph in alert_paragraphs:
-        p_html = str(paragraph)
-        assert '<script>' not in p_html
-        assert '<img ' not in p_html
-        assert '<svg' not in p_html
-        assert '<a href="javascript:' not in p_html

--- a/tests/app/test_utils.py
+++ b/tests/app/test_utils.py
@@ -86,35 +86,6 @@ def test_paragraphize_converts_newlines_to_paragraphs():
     assert paragraphize(lines, classes="a-class") == Markup(expected)
 
 
-@pytest.mark.parametrize('malicious_content', [
-    '<script>alert("xss")</script>',
-    '<img src=x onerror=alert(1)>',
-    '<a href="javascript:alert(1)">click</a>',
-    '"><svg onload=alert(1)>',
-    '"><script>alert(document.cookie)</script>',
-])
-def test_paragraphize_escapes_html(malicious_content):
-    result = paragraphize(malicious_content)
-    assert '<script>' not in result
-    assert '<img ' not in result
-    assert '<a ' not in result
-    assert '<svg ' not in result
-    assert '&lt;' in result
-
-
-@pytest.mark.parametrize('malicious_content', [
-    '<script>alert("xss")</script>',
-    '<img src=x onerror=alert(1)>',
-    '<a href="javascript:alert(1)">click</a>',
-])
-def test_paragraphize_truncated_escapes_html(malicious_content):
-    result = paragraphize(malicious_content, truncate=True)
-    assert '<script>' not in result
-    assert '<img ' not in result
-    assert '<a ' not in result
-    assert '&lt;' in result
-
-
 @pytest.mark.parametrize('lat,lon,in_uk', [
     [66.55, 25.889, False],  # somewhere in Finland
     [52.22035, 1.58242, True]  # somewhere in UK


### PR DESCRIPTION
This reverts commit a00ceb654425a74d83c2d8d0362a0f601c14fbfb. There's some weirdness with double-escaping going on.